### PR TITLE
feat: Implement CEL Engine

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -6,9 +6,9 @@ This document outlines the detailed, phased development plan for the "Veritas" v
 
 **Goal**: Build a minimal, robust engine capable of evaluating CEL expressions and performing basic type and field validation.
 
--   **[ ] 1.1: `Engine` Implementation**
-    -   [ ] 1.1.1: Define an `Engine` struct that encapsulates `cel.Env` and an LRU cache (`lru.Cache`) for compiled `cel.Program`s.
-    -   [ ] 1.1.2: Use `log/slog` for internal tracing. Log cache misses and program generations at the `Debug` level.
+-   **[x] 1.1: `Engine` Implementation**
+    -   [x] 1.1.1: Define an `Engine` struct that encapsulates `cel.Env` and an LRU cache (`lru.Cache`) for compiled `cel.Program`s.
+    -   [x] 1.1.2: Use `log/slog` for internal tracing. Log cache misses and program generations at the `Debug` level.
     -   [ ] 1.1.3: Implement a framework to register custom CEL functions (e.g., `strings.ToUpper`, `matches`).
 
 -   **[ ] 1.2: `Validator` Implementation**

--- a/engine_test.go
+++ b/engine_test.go
@@ -1,15 +1,96 @@
 package veritas
 
 import (
+	"bytes"
+	"log/slog"
+	"strings"
 	"testing"
+
+	"github.com/google/cel-go/cel"
+	"github.com/google/go-cmp/cmp"
 )
 
-func TestEngine(t *testing.T) {
-	// TODO: Write tests for engine initialization.
-	// TODO: Write tests for getProgram caching logic.
-	//   - Test case 1: Cache miss, successful compilation.
-	//   - Test case 2: Cache hit, program is retrieved without compilation.
-	//   - Test case 3: Invalid CEL expression, compilation fails.
-	// dummy assertion to avoid empty function error
-	t.Log("TestEngine placeholder")
+func TestNewEngine(t *testing.T) {
+	t.Parallel()
+
+	logger := slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil))
+	engine, err := NewEngine(logger)
+
+	if err != nil {
+		t.Fatalf("NewEngine() unexpected error: %v", err)
+	}
+	if engine == nil {
+		t.Fatal("NewEngine() returned nil engine")
+	}
+	if engine.env == nil {
+		t.Error("NewEngine() did not initialize CEL environment")
+	}
+	if engine.cache == nil {
+		t.Error("NewEngine() did not initialize cache")
+	}
+	if engine.logger == nil {
+		t.Error("NewEngine() did not initialize logger")
+	}
+}
+
+func TestEngine_getProgram(t *testing.T) {
+	t.Parallel()
+
+	var logBuf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&logBuf, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	}))
+	engine, err := NewEngine(logger)
+	if err != nil {
+		t.Fatalf("Failed to create engine: %v", err)
+	}
+
+	rule := `1 < 2`
+
+	// 1. Cache miss
+	logBuf.Reset()
+	prog1, err1 := engine.getProgram(rule)
+	if err1 != nil {
+		t.Fatalf("getProgram() first call failed: %v", err1)
+	}
+	if prog1 == nil {
+		t.Fatal("getProgram() first call returned nil program")
+	}
+	if !strings.Contains(logBuf.String(), "cache miss") {
+		t.Errorf("Expected 'cache miss' log, got: %s", logBuf.String())
+	}
+
+	// 2. Cache hit
+	logBuf.Reset()
+	prog2, err2 := engine.getProgram(rule)
+	if err2 != nil {
+		t.Fatalf("getProgram() second call failed: %v", err2)
+	}
+	if !strings.Contains(logBuf.String(), "cache hit") {
+		t.Errorf("Expected 'cache hit' log, got: %s", logBuf.String())
+	}
+
+	// To check if the programs are functionally the same, we can evaluate them
+	// and compare the results.
+	out1, _, err := prog1.Eval(cel.NoVars())
+	if err != nil {
+		t.Fatalf("prog1.Eval() failed: %v", err)
+	}
+	out2, _, err := prog2.Eval(cel.NoVars())
+	if err != nil {
+		t.Fatalf("prog2.Eval() failed: %v", err)
+	}
+	if diff := cmp.Diff(out1, out2); diff != "" {
+		t.Errorf("Program evaluation results mismatch (-want +got):\n%s", diff)
+	}
+
+	// 3. Invalid expression
+	_, err3 := engine.getProgram(`1 <`)
+	if err3 == nil {
+		t.Fatal("getProgram() with invalid rule did not return an error")
+	}
+	// We only check that an error is returned, as the exact message can change.
+	if err3 == nil {
+		t.Fatal("getProgram() with invalid rule did not return an error")
+	}
 }


### PR DESCRIPTION
This commit implements the core CEL engine (`veritas.Engine`) as outlined in task 1.1 of the TODO list.

Key changes:
- Implemented `NewEngine` to initialize the CEL environment and an LRU cache for compiled programs.
- Implemented `getProgram` to handle the compilation and caching of CEL rules. It logs cache hits/misses for debugging.
- Added a comprehensive test suite in `engine_test.go` to verify the engine's initialization, program caching (miss and hit), and error handling for invalid expressions.
- Updated `TODO.md` to mark the `Engine` implementation tasks as complete.