### PR TITLE
refactor: Attempt to fix validation logic and tests

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -16,6 +16,7 @@ This document outlines the detailed, phased development plan for the "Veritas" v
     -   [~] 1.2.2: Implement the primary `Validate(obj any) error` method. Use `log/slog.Error` for internal errors like reflection failures. (Note: Implementation is in progress, facing issues with dynamic type registration in cel-go).
     -   [x] 1.2.3: Implement logic to apply `TypeRules` and `FieldRules` separately, aggregating all validation failures using `errors.Join`.
     -   [x] 1.2.4: Ensure error messages are contextual, including the type and field name (e.g., `User.Email: validation failed...`).
+    -   [ ] 1.2.5: **[TODO]** Resolve the `unsupported type` error in `cel-go`. Investigate the correct way to register native Go structs with the CEL environment to allow validation of struct fields. This is currently blocking all validation tests.
 
 -   **[x] 1.3: Rule Provider Implementation**
     -   [x] 1.3.1: Define the `ValidationRuleSet` struct (containing `TypeRules`, `FieldRules`).

--- a/testdata/rules/user.json
+++ b/testdata/rules/user.json
@@ -5,10 +5,10 @@
     ],
     "fieldRules": {
       "Name": [
-        "this.size() > 0"
+        "this.Name.size() > 0"
       ],
       "Email": [
-        "this.matches('^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\\\.[a-zA-Z]{2,}$')"
+        "this.Email.matches('^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\\\.[a-zA-Z]{2,}$')"
       ]
     }
   }

--- a/validator.go
+++ b/validator.go
@@ -34,8 +34,7 @@ func NewValidator(engine *Engine, provider RuleProvider, logger *slog.Logger) (*
 // It returns a joined error containing all validation failures.
 func (v *Validator) Validate(obj any) error {
 	val := reflect.ValueOf(obj)
-	isPtr := val.Kind() == reflect.Ptr
-	if isPtr {
+	if val.Kind() == reflect.Ptr {
 		val = val.Elem()
 	}
 	typ := val.Type()
@@ -48,42 +47,21 @@ func (v *Validator) Validate(obj any) error {
 	}
 
 	var allErrors []error
-
-	// Create a new environment with the type of the object registered.
-	// This allows CEL to understand the object's structure.
-	env, err := v.engine.env.Extend(cel.Types(reflect.New(typ).Interface()), cel.Declarations(cel.Variable("this", cel.ObjectType(typ.Name()))))
-	if err != nil {
-		v.logger.Error("failed to extend env with object type", "type", typeName, "error", err)
-		return NewFatalError(fmt.Sprintf("failed to register type %s: %v", typeName, err))
-	}
+	vars := map[string]any{"this": obj}
 
 	// 1. Type-level validation
-	typeVars := map[string]any{
-		"this": obj,
-	}
 	for _, rule := range ruleSet.TypeRules {
-		err := v.evaluateRuleWithEnv(env, rule, typeVars, typeName, "")
+		// For type rules, the fieldName is empty.
+		err := v.evaluateRule(rule, obj, vars, typeName, "")
 		if err != nil {
 			allErrors = append(allErrors, err)
 		}
 	}
 
 	// 2. Field-level validation
-	for i := 0; i < val.NumField(); i++ {
-		field := typ.Field(i)
-		fieldVal := val.Field(i)
-		rules, ok := ruleSet.FieldRules[field.Name]
-		if !ok {
-			continue
-		}
-
-		fieldVars := map[string]any{
-			"this": fieldVal.Interface(),
-		}
+	for fieldName, rules := range ruleSet.FieldRules {
 		for _, rule := range rules {
-			// Note: We use the original engine's env for field rules,
-			// as they operate on primitive types ('this').
-			err := v.evaluateRule(rule, fieldVars, typeName, field.Name)
+			err := v.evaluateRule(rule, obj, vars, typeName, fieldName)
 			if err != nil {
 				allErrors = append(allErrors, err)
 			}
@@ -97,10 +75,16 @@ func (v *Validator) Validate(obj any) error {
 	return nil
 }
 
+// evaluateRule compiles (with caching) and runs a single CEL rule.
+func (v *Validator) evaluateRule(rule string, obj any, vars map[string]any, typeName, fieldName string) error {
+	// Dynamically register the type of the object for this evaluation.
+	// This makes the validator flexible to any type without pre-registration.
+	opts := []cel.EnvOption{
+		cel.Types(obj),
+		cel.Variable("this", cel.ObjectType(typeName)),
+	}
 
-// evaluateRule compiles and runs a single CEL rule using the validator's main engine.
-func (v *Validator) evaluateRule(rule string, vars map[string]any, typeName, fieldName string) error {
-	prog, err := v.engine.getProgram(rule, cel.Variable("this", cel.DynType))
+	prog, err := v.engine.getProgram(rule, opts...)
 	if err != nil {
 		v.logger.Error("failed to compile rule", "rule", rule, "error", err)
 		return NewFatalError(fmt.Sprintf("rule compilation error for %s: %s", typeName, err))
@@ -109,35 +93,6 @@ func (v *Validator) evaluateRule(rule string, vars map[string]any, typeName, fie
 	out, _, err := prog.Eval(vars)
 	if err != nil {
 		v.logger.Error("failed to evaluate rule", "rule", rule, "type", typeName, "field", fieldName, "error", err)
-		return NewValidationError(typeName, fieldName, "evaluation error")
-	}
-
-	if valid, ok := out.Value().(bool); !ok || !valid {
-		return NewValidationError(typeName, fieldName, rule)
-	}
-
-	return nil
-}
-
-// evaluateRuleWithEnv compiles and runs a single CEL rule using a custom environment.
-// This is used for type-level rules where the object's type needs to be registered at runtime.
-// This version does not use caching.
-func (v *Validator) evaluateRuleWithEnv(env *cel.Env, rule string, vars map[string]any, typeName, fieldName string) error {
-	ast, issues := env.Compile(rule)
-	if issues != nil && issues.Err() != nil {
-		v.logger.Error("failed to compile rule with custom env", "rule", rule, "error", issues.Err())
-		return NewFatalError(fmt.Sprintf("rule compilation error for %s: %s", typeName, issues.Err()))
-	}
-
-	prog, err := env.Program(ast)
-	if err != nil {
-		v.logger.Error("failed to create program with custom env", "rule", rule, "error", err)
-		return NewFatalError(fmt.Sprintf("program creation error for %s: %s", typeName, err))
-	}
-
-	out, _, err := prog.Eval(vars)
-	if err != nil {
-		v.logger.Error("failed to evaluate rule with custom env", "rule", rule, "type", typeName, "field", fieldName, "error", err)
 		return NewValidationError(typeName, fieldName, "evaluation error")
 	}
 

--- a/validator_test.go
+++ b/validator_test.go
@@ -62,8 +62,8 @@ func TestValidator_Validate(t *testing.T) {
 				Age:   10,
 			},
 			wantErr: errors.Join(
-				NewValidationError("MockUser", "Name", "this.size() > 0"),
-				NewValidationError("MockUser", "Email", `this.matches('^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\\\.[a-zA-Z]{2,}$')`),
+				NewValidationError("MockUser", "Name", "this.Name.size() > 0"),
+				NewValidationError("MockUser", "Email", `this.Email.matches('^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\\\.[a-zA-Z]{2,}$')`),
 			),
 		},
 		{


### PR DESCRIPTION
This commit addresses tasks 1.2.2 and 1.4.1 from TODO.md by refactoring the validation logic and updating the corresponding tests.

Changes:
- `validator.go`:
  - Refactored the `Validate` method to unify the evaluation logic for both type-level and field-level rules.
  - Modified the `evaluateRule` method to dynamically register the object's type with the `cel.Env` during evaluation.
- `testdata/rules/user.json`:
  - Updated field rules to reference the top-level object via `this`, aligning with the changes in `validator.go`.
- `validator_test.go`:
  - Adjusted the expected error messages to match the updated rule definitions.

Current Status:
The validation tests are still failing due to a persistent issue with type registration in cel-go. I attempted multiple approaches to register native Go structs with `cel.Types()` (e.g., passing by pointer, by value, via `cel.Lib`, pre-registering in the engine), but all resulted in an `unsupported type` error.

The final implementation attempts to register types dynamically within the `Validate` method call, but this is the source of the error. Further investigation is required to determine the correct method for registering native Go structs with the CEL environment to make them available for validation rules.