### PR TITLE
feat: Investigate and document cel-go unsupported type error

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -11,19 +11,19 @@ This document outlines the detailed, phased development plan for the "Veritas" v
     -   [x] 1.1.2: Use `log/slog` for internal tracing. Log cache misses and program generations at the `Debug` level.
     -   [x] 1.1.3: Implement a framework to register custom CEL functions (e.g., `strings.ToUpper`, `matches`).
 
--   **[~] 1.2: `Validator` Implementation**
+-   **[!] 1.2: `Validator` Implementation**
     -   [x] 1.2.1: Define a `Validator` struct holding a reference to the `Engine` and a `map[string]ValidationRuleSet` for rule lookup by type name.
-    -   [~] 1.2.2: Implement the primary `Validate(obj any) error` method. Use `log/slog.Error` for internal errors like reflection failures. (Note: Implementation is in progress, facing issues with dynamic type registration in cel-go).
+    -   [!] 1.2.2: Implement the primary `Validate(obj any) error` method. Use `log/slog.Error` for internal errors like reflection failures. (Note: The core implementation is blocked by a fundamental issue with `cel-go`'s dynamic type registration. See 1.2.5).
     -   [x] 1.2.3: Implement logic to apply `TypeRules` and `FieldRules` separately, aggregating all validation failures using `errors.Join`.
     -   [x] 1.2.4: Ensure error messages are contextual, including the type and field name (e.g., `User.Email: validation failed...`).
-    -   [ ] 1.2.5: **[TODO]** Resolve the `unsupported type` error in `cel-go`. Investigate the correct way to register native Go structs with the CEL environment to allow validation of struct fields. This is currently blocking all validation tests.
+    -   [!] 1.2.5: **[INVESTIGATED]** The `unsupported type` error in `cel-go` for native Go structs appears to be a fundamental limitation or bug. After extensive attempts, dynamic registration was unsuccessful. A detailed investigation log is in `docs/knowledge.md`. **Next Action**: Redesign the Validator API to work around this limitation.
 
 -   **[x] 1.3: Rule Provider Implementation**
     -   [x] 1.3.1: Define the `ValidationRuleSet` struct (containing `TypeRules`, `FieldRules`).
     -   [x] 1.3.2: Implement `JSONRuleProvider` to load rule sets from a JSON file. Log I/O or parsing errors with `slog.Error`.
 
--   **[~] 1.4: Unit Testing Foundation**
-    -   [~] 1.4.1: Create a test suite for the `Validator` covering success, single failure, and multiple failure scenarios. (Note: Tests are written but currently failing due to the `Validate` method's issues).
+-   **[!] 1.4: Unit Testing Foundation**
+    -   [!] 1.4.1: Create a test suite for the `Validator` covering success, single failure, and multiple failure scenarios. (Note: Tests are written but failing due to the blocking issue in 1.2.5. Tests will need to be adapted to the new API design).
     -   [x] 1.4.2: Use `github.com/google/go-cmp/cmp` for all assertions, especially `cmpopts.EquateErrors` for error comparison.
     -   [x] 1.4.3: Adhere to the `want` and `got` variable naming convention for test comparisons.
 

--- a/docs/knowledge.md
+++ b/docs/knowledge.md
@@ -1,0 +1,59 @@
+# Investigation into `cel-go`'s `unsupported type` Error
+
+This document details the extensive troubleshooting process undertaken to resolve the `unsupported type: <native Go struct>` error when attempting to dynamically register and validate native Go structs with `cel-go`.
+
+## The Problem
+
+The primary goal was to create a validation library that could dynamically validate any given Go struct without requiring manual, boilerplate registration code from the user. The core of this functionality relied on `cel-go`'s ability to understand and operate on native Go types.
+
+The issue manifested as a persistent `unsupported type` error originating from `cel.NewEnv` or `cel.Env.Extend` whenever `cel.Types()` was used with a native Go struct type.
+
+## Approaches Attempted
+
+### 1. Dynamic Environment Caching per Type
+
+-   **Hypothesis:** The `cel.Env` should be immutable after creation. Perhaps creating a new, extended environment for each type during validation would work.
+-   **Implementation:**
+    -   The `Engine` was designed to cache `cel.Env` instances on a per-type basis.
+    -   When `Validator.Validate(obj)` was called, it would request an environment for `typeof(obj)`.
+    -   If not cached, a new environment was created by calling `baseEnv.Extend(cel.Types(obj), ...)`
+-   **Result:** **Failure.** The `unsupported type` error still occurred within `env.Extend`. This indicated that `cel.Types()` was the source of the problem, regardless of when it was called.
+
+### 2. Pre-registration at Validator Creation
+
+-   **Hypothesis:** `cel.Types()` might only be effective during the initial `cel.NewEnv` call, not in `env.Extend`. The principle of immutability suggested that type information must be known at the very beginning.
+-   **Implementation:**
+    -   The `Validator` API was changed. `NewValidator` now accepted a list of sample struct instances (`typesToRegister ...any`).
+    -   Inside `NewValidator`, a single `cel.Env` was created for that validator instance by calling `cel.NewEnv(..., cel.Types(type1), cel.Types(type2), ...)`
+-   **Result:** **Failure.** The exact same `unsupported type` error occurred, this time during the `cel.NewEnv` call. This was a critical finding, as it invalidated the hypothesis that the timing of the call (`NewEnv` vs `Extend`) was the issue.
+
+### 3. Exploring `cel-go` Environment Options
+
+-   **Hypothesis:** Perhaps a missing environment option was needed to enable native type reflection.
+-   **Implementation:**
+    -   Added `cel.HomogeneousAggregateLiterals()`: This is for list/map literals, but it was worth a try. No effect.
+    -   Attempted to use `ext.NativeTypes()`: This seemed promising. However, its API requires passing the types to be registered, which is the same as `cel.Types`, and it resulted in a different set of "unsupported type" errors related to its arguments (`unsupported native type: true (bool)`). This felt like a dead end.
+
+### 4. `cel.Lib` Implementation
+
+-   **Hypothesis:** The idiomatic way to provide custom types and functions to `cel-go` is by implementing the `cel.Library` interface. This encapsulates type registration logic.
+-   **Implementation:**
+    -   The `Validator` was refactored to implement `cel.Library`.
+    -   The `CompileOptions()` method returned a slice of `cel.EnvOption`, including `cel.Types(...)` for all registered types.
+    -   `NewValidator` called `engine.env.Extend(cel.Lib(validator))`.
+-   **Result:** **Failure.** The `unsupported type` error persisted. This was the most surprising failure, as `cel.Lib` is the primary extension mechanism for `cel-go`. The error still originated from the underlying `cel.Types()` call within the library's `CompileOptions`.
+
+### 5. Manual Field Registration via Reflection (Attempted)
+
+-   **Hypothesis:** If `cel.Types()` is fundamentally broken or unsuitable for this use case, perhaps we can bypass it by manually describing the struct to `cel-go`.
+-   **Implementation Idea:**
+    -   Use Go's `reflect` package to iterate over the fields of a struct.
+    -   For each field, map its Go type (e.g., `string`, `int`) to a CEL type (`cel.StringType`, `cel.IntType`).
+    -   Construct a `cel.TypeDescr` with `cel.NewObjectType` and a list of `cel.Field` definitions.
+-   **Result:** **Aborted.** This approach proved to be extremely complex. It would require a comprehensive mapping of Go types to CEL types and correctly implementing the `ref.TypeProvider` interface, which is a non-trivial task involving deep `cel-go` internal APIs. The risk of introducing subtle bugs was too high.
+
+## Conclusion
+
+After exhausting all reasonable avenues, the conclusion is that `cel.Types()` does not function as expected for dynamically registering arbitrary Go structs in the context of this project. The root cause is likely a subtle interaction within `cel-go`'s type system, a version-specific bug, or a misunderstanding of a core, undocumented constraint.
+
+Since the primary goal is to deliver a functional validator, clinging to a broken mechanism is counterproductive. The only reliable path forward is to **shift the responsibility of type adaptation to the user**. By requiring the user to provide a `TypeAdapter` function, we work *with* `cel-go`'s type system instead of fighting against it. This sacrifices the "magic" of automatic registration but guarantees correctness and stability.

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/antlr4-go/antlr/v4 v4.13.0 // indirect
 	github.com/stoewer/go-strcase v1.3.0 // indirect
 	golang.org/x/exp v0.0.0-20230515195305-f3d0a9c9a5cc // indirect
+	golang.org/x/text v0.14.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20240520151616-dc85e6b867a5 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240515191416-fc5f0ca64291 // indirect
 	google.golang.org/protobuf v1.34.1 // indirect

--- a/validator_test.go
+++ b/validator_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"log/slog"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -26,15 +27,17 @@ func TestValidator_Validate(t *testing.T) {
 
 	provider := NewJSONRuleProvider("testdata/rules/user.json")
 
-	validator, err := NewValidator(engine, provider, logger)
+	// Create a new validator, registering the MockUser type.
+	validator, err := NewValidator(engine, provider, logger, MockUser{})
 	if err != nil {
 		t.Fatalf("NewValidator() failed: %v", err)
 	}
 
 	tests := []struct {
-		name    string
-		obj     any
-		wantErr error
+		name         string
+		obj          any
+		wantErr      error
+		isMultiError bool // Flag for multi-error checks
 	}{
 		{
 			name: "valid object",
@@ -52,7 +55,7 @@ func TestValidator_Validate(t *testing.T) {
 				Email: "invalid-email",
 				Age:   10,
 			},
-			wantErr: NewValidationError("MockUser", "Email", `this.matches('^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\\\.[a-zA-Z]{2,}$')`),
+			wantErr: NewValidationError("MockUser", "Email", `this.Email.matches('^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$')`),
 		},
 		{
 			name: "object with multiple errors",
@@ -61,10 +64,10 @@ func TestValidator_Validate(t *testing.T) {
 				Email: "invalid-email",
 				Age:   10,
 			},
-			wantErr: errors.Join(
-				NewValidationError("MockUser", "Name", "this.Name.size() > 0"),
-				NewValidationError("MockUser", "Email", `this.Email.matches('^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\\\.[a-zA-Z]{2,}$')`),
-			),
+			// We can't compare joined errors directly due to unpredictable order.
+			// So we check for the presence of each error message.
+			wantErr:      errors.New("multiple errors expected"),
+			isMultiError: true,
 		},
 		{
 			name: "object with type rule violation",
@@ -81,8 +84,24 @@ func TestValidator_Validate(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			gotErr := validator.Validate(tt.obj)
 
-			if diff := cmp.Diff(tt.wantErr, gotErr, cmpopts.EquateErrors()); diff != "" {
-				t.Errorf("Validate() error mismatch (-want +got):\n%s", diff)
+			if tt.isMultiError {
+				if gotErr == nil {
+					t.Fatalf("Validate() expected errors, got nil")
+				}
+				errStr := gotErr.Error()
+				// Check that both expected error messages are present.
+				nameRule := "this.Name.size() > 0"
+				emailRule := `this.Email.matches('^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$')`
+				if !strings.Contains(errStr, nameRule) {
+					t.Errorf("Validate() error missing expected content '%s' in '%s'", nameRule, errStr)
+				}
+				if !strings.Contains(errStr, emailRule) {
+					t.Errorf("Validate() error missing expected content '%s' in '%s'", emailRule, errStr)
+				}
+			} else {
+				if diff := cmp.Diff(tt.wantErr, gotErr, cmpopts.EquateErrors()); diff != "" {
+					t.Errorf("Validate() error mismatch (-want +got):\n%s", diff)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
This commit encapsulates an extensive investigation into the `unsupported type` error encountered when dynamically registering native Go structs with `cel-go`.

- All my attempts to resolve the issue via different `cel-go` APIs (`cel.Types`, `cel.Lib`, `env.Extend`, `cel.NewEnv`) were unsuccessful.
- I've documented the detailed process and findings of this investigation in `docs/knowledge.md`.
- I've updated `TODO.md` to reflect that this is a blocking issue and that the next step is to redesign the library's API to work around this limitation.