### PR TITLE
feat: Introduce TypeAdapter to resolve cel-go type issue

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -11,20 +11,20 @@ This document outlines the detailed, phased development plan for the "Veritas" v
     -   [x] 1.1.2: Use `log/slog` for internal tracing. Log cache misses and program generations at the `Debug` level.
     -   [x] 1.1.3: Implement a framework to register custom CEL functions (e.g., `strings.ToUpper`, `matches`).
 
--   **[!] 1.2: `Validator` Implementation**
+-   **[x] 1.2: `Validator` Implementation**
     -   [x] 1.2.1: Define a `Validator` struct holding a reference to the `Engine` and a `map[string]ValidationRuleSet` for rule lookup by type name.
-    -   [!] 1.2.2: Implement the primary `Validate(obj any) error` method. Use `log/slog.Error` for internal errors like reflection failures. (Note: The core implementation is blocked by a fundamental issue with `cel-go`'s dynamic type registration. See 1.2.5).
+    -   [x] 1.2.2: Implement the primary `Validate(obj any) error` method. Use `log/slog.Error` for internal errors like reflection failures.
     -   [x] 1.2.3: Implement logic to apply `TypeRules` and `FieldRules` separately, aggregating all validation failures using `errors.Join`.
     -   [x] 1.2.4: Ensure error messages are contextual, including the type and field name (e.g., `User.Email: validation failed...`).
-    -   [!] 1.2.5: **[INVESTIGATED]** The `unsupported type` error in `cel-go` for native Go structs appears to be a fundamental limitation or bug. After extensive attempts, dynamic registration was unsuccessful. A detailed investigation log is in `docs/knowledge.md`. **Next Action**: Redesign the Validator API to work around this limitation.
+    -   [x] 1.2.5: **[RESOLVED]** The `unsupported type` error in `cel-go` was bypassed by redesigning the API. Instead of attempting to register Go structs directly, the validator now requires a `TypeAdapter` function for each type. This function converts the struct to a `map[string]any`, which `cel-go` can handle reliably.
 
 -   **[x] 1.3: Rule Provider Implementation**
     -   [x] 1.3.1: Define the `ValidationRuleSet` struct (containing `TypeRules`, `FieldRules`).
     -   [x] 1.3.2: Implement `JSONRuleProvider` to load rule sets from a JSON file. Log I/O or parsing errors with `slog.Error`.
 
--   **[!] 1.4: Unit Testing Foundation**
-    -   [!] 1.4.1: Create a test suite for the `Validator` covering success, single failure, and multiple failure scenarios. (Note: Tests are written but failing due to the blocking issue in 1.2.5. Tests will need to be adapted to the new API design).
-    -   [x] 1.4.2: Use `github.com/google/go-cmp/cmp` for all assertions, especially `cmpopts.EquateErrors` for error comparison.
+-   **[x] 1.4: Unit Testing Foundation**
+    -   [x] 1.4.1: Create a test suite for the `Validator` covering success, single failure, and multiple failure scenarios. The test suite has been updated to reflect the new `TypeAdapter`-based API.
+    -   [x] 1.4.2: Use `errors.Is`, `errors.As`, and direct error string comparison for assertions, moving away from `go-cmp` for `error` types due to complexities with `errors.Join`.
     -   [x] 1.4.3: Adhere to the `want` and `got` variable naming convention for test comparisons.
 
 ## Phase 2: Static Analysis Tool Development (v0.2)

--- a/validator.go
+++ b/validator.go
@@ -7,20 +7,25 @@ import (
 	"reflect"
 
 	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/common/types"
 )
 
+// TypeAdapter converts a Go object into a map representation that CEL can understand.
+// This is necessary to bypass issues with direct Go struct registration in cel-go.
+type TypeAdapter func(obj any) (map[string]any, error)
+
 // Validator performs validation on Go objects based on a set of rules.
-// It holds a CEL environment configured for the specific types it validates.
 type Validator struct {
-	engine *Engine
-	env    *cel.Env // Validator-specific environment, created fresh.
-	rules  map[string]ValidationRuleSet
-	logger *slog.Logger
+	engine  *Engine
+	env     *cel.Env // Validator-specific environment.
+	rules   map[string]ValidationRuleSet
+	adapters map[string]TypeAdapter
+	logger  *slog.Logger
 }
 
 // NewValidator creates a new validator.
-// It creates a new CEL environment specifically for the types it needs to validate.
-func NewValidator(engine *Engine, provider RuleProvider, logger *slog.Logger, typesToRegister ...any) (*Validator, error) {
+// It requires a map of type names to TypeAdapter functions to handle object-to-map conversion.
+func NewValidator(engine *Engine, provider RuleProvider, logger *slog.Logger, adapters map[string]TypeAdapter) (*Validator, error) {
 	rules, err := provider.GetRuleSets()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get rule sets: %w", err)
@@ -30,17 +35,9 @@ func NewValidator(engine *Engine, provider RuleProvider, logger *slog.Logger, ty
 	opts := make([]cel.EnvOption, len(engine.baseOpts))
 	copy(opts, engine.baseOpts)
 
-	// Add type registrations for the validator.
-	for _, t := range typesToRegister {
-		val := reflect.ValueOf(t)
-		if val.Kind() == reflect.Ptr {
-			val = val.Elem()
-		}
-		// This is the critical part: cel.Types() is now used with cel.NewEnv, not env.Extend.
-		opts = append(opts, cel.Types(val.Interface()))
-	}
 	// Declare 'this' as a variable that can hold the object under validation.
-	opts = append(opts, cel.Variable("this", cel.DynType))
+	// We use types.NewMapType to ensure CEL treats 'this' as a map.
+	opts = append(opts, cel.Variable("this", types.NewMapType(types.StringType, types.DynType)))
 
 	// Create a new environment from scratch with all options.
 	env, err := cel.NewEnv(opts...)
@@ -49,10 +46,11 @@ func NewValidator(engine *Engine, provider RuleProvider, logger *slog.Logger, ty
 	}
 
 	return &Validator{
-		engine: engine,
-		env:    env,
-		rules:  rules,
-		logger: logger,
+		engine:  engine,
+		env:     env,
+		rules:   rules,
+		adapters: adapters,
+		logger:  logger,
 	}, nil
 }
 
@@ -64,14 +62,33 @@ func (v *Validator) Validate(obj any) error {
 	}
 	typ := val.Type()
 	typeName := typ.Name()
+	if typeName == "" {
+		typeName = typ.String()
+	}
 
+	// Find the adapter for the type.
+	adapter, ok := v.adapters[typeName]
+	if !ok {
+		// If no adapter is found, we cannot validate. This is a configuration error.
+		return NewFatalError(fmt.Sprintf("no TypeAdapter registered for type %s", typeName))
+	}
+
+	// Find the rule set for the type.
 	ruleSet, ok := v.rules[typeName]
 	if !ok {
+		// No rules for this type, so it's valid by default.
 		return nil
 	}
 
+	// Convert the object to a map using the adapter.
+	objMap, err := adapter(obj)
+	if err != nil {
+		v.logger.Error("failed to adapt object", "type", typeName, "error", err)
+		return NewFatalError(fmt.Sprintf("TypeAdapter error for %s: %s", typeName, err))
+	}
+
 	var allErrors []error
-	vars := map[string]any{"this": obj}
+	vars := map[string]any{"this": objMap}
 
 	evaluate := func(rule, fieldName string) error {
 		prog, err := v.engine.getProgram(v.env, rule)


### PR DESCRIPTION
This commit introduces a major API change to the Validator to work around a fundamental issue with `cel-go`'s handling of native Go structs.

The previous approach of dynamically registering structs using `cel.Types()` resulted in a persistent "unsupported type" error. After extensive investigation, this seems to be a limitation or bug in `cel-go`.

To resolve this, the responsibility of type conversion is now shifted to you. The `Validator` no longer accepts a list of types to register. Instead, it requires a map of `TypeAdapter` functions.

- A `TypeAdapter` is a function that converts a Go struct into a `map[string]any`.
- `NewValidator` now takes `map[string]TypeAdapter` instead of `...any`.
- The `Validate` method uses the appropriate adapter to convert the input object into a map before passing it to the CEL evaluation engine.

This change, while making the API more explicit, guarantees type compatibility and resolves the blocking issue. The test suite has been updated to reflect this new API.