### PR TITLE
feat: Implement veritas CLI and rule generation

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -37,15 +37,15 @@ This document outlines the detailed, phased development plan for the "Veritas" v
 -   **[x] 2.2: Rule Extraction Logic**
     -   [x] 2.2.1: Extract field-level rules from `validate:"..."` struct tags.
     -   [x] 2.2.2: Extract type-level rules from special `// @cel: ...` comments preceding a `struct` definition.
-    -   [ ] 2.2.3: Implement a mapping from common shorthands (`required`, `email`, etc.) to their corresponding CEL expressions.
+    -   [x] 2.2.3: Implement a mapping from common shorthands (`required`, `email`, etc.) to their corresponding CEL expressions.
 
--   **[ ] 2.3: `veritas` CLI Implementation**
-    -   [ ] 2.3.1: Implement logic to output the extracted rules as a structured JSON file.
-    -   [ ] 2.3.2: Use `slog.Info` for progress reporting and `slog.Debug` for detailed parsing steps.
+-   [x] 2.3: `veritas` CLI Implementation
+    -   [x] 2.3.1: Implement logic to output the extracted rules as a structured JSON file.
+    -   [x] 2.3.2: Use `slog.Info` for progress reporting and `slog.Debug` for detailed parsing steps.
 
--   **[ ] 2.4: Static Analysis Tool Testing**
-    -   [ ] 2.4.1: Prepare sample Go source files and their expected JSON output as test data.
-    -   [ ] 2.4.2: Write tests that run the generator and compare the actual output against the expected JSON using `go-cmp/cmp`.
+-   [x] 2.4: Static Analysis Tool Testing
+    -   [x] 2.4.1: Prepare sample Go source files and their expected JSON output as test data.
+    -   [x] 2.4.2: Write tests that run the generator and compare the actual output against the expected JSON using `go-cmp/cmp`.
 
 ## Phase 3: Advanced Data Structures Support (v0.3)
 

--- a/cmd/veritas/main.go
+++ b/cmd/veritas/main.go
@@ -1,10 +1,14 @@
 package main
 
 import (
+	"encoding/json"
 	"flag"
 	"fmt"
 	"log/slog"
 	"os"
+
+	"github.com/podhmo/veritas"
+	"golang.org/x/tools/go/packages"
 )
 
 func main() {
@@ -33,10 +37,49 @@ func main() {
 }
 
 func run(inPath, outFile string, logger *slog.Logger) error {
-	// Placeholder for the main generation logic.
-	fmt.Printf("Parsing %s and writing to %s...\n", inPath, outFile)
-	// parser := NewParser(logger)
-	// ruleSet, err := parser.Parse(inPath)
-	// ...
+	// Find all Go files in the provided path.
+	cfg := &packages.Config{
+		Mode: packages.NeedFiles,
+	}
+	pkgs, err := packages.Load(cfg, inPath)
+	if err != nil {
+		return fmt.Errorf("failed to load packages for path %q: %w", inPath, err)
+	}
+	if packages.PrintErrors(pkgs) > 0 {
+		return fmt.Errorf("packages contain errors")
+	}
+
+	parser := NewParser(logger)
+	allRuleSets := make(map[string]veritas.ValidationRuleSet)
+
+	// Parse each file.
+	for _, pkg := range pkgs {
+		for _, goFile := range pkg.GoFiles {
+			logger.Debug("parsing file", "path", goFile)
+			ruleSets, err := parser.Parse(goFile)
+			if err != nil {
+				logger.Warn("failed to parse file, skipping", "file", goFile, "error", err)
+				continue
+			}
+			// Merge the rule sets.
+			for k, v := range ruleSets {
+				allRuleSets[k] = v
+			}
+		}
+	}
+
+	// Marshal the combined rule sets into JSON.
+	jsonData, err := json.MarshalIndent(allRuleSets, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal rule sets to JSON: %w", err)
+	}
+
+	// Write the JSON to the output file.
+	if err := os.WriteFile(outFile, jsonData, 0644); err != nil {
+		return fmt.Errorf("failed to write JSON to file %q: %w", outFile, err)
+	}
+
+	logger.Info("successfully wrote rules", "count", len(allRuleSets), "file", outFile)
+
 	return nil
 }

--- a/cmd/veritas/main_test.go
+++ b/cmd/veritas/main_test.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/podhmo/veritas"
+)
+
+// TestEndToEnd runs the veritas CLI tool and verifies its output.
+func TestEndToEnd(t *testing.T) {
+	// Define paths
+	tempDir := t.TempDir()
+	outputJSONPath := filepath.Join(tempDir, "test_rules.json")
+	inputPath := "../../testdata/sources/..." // Use recursive path
+
+	// Build the veritas binary
+	buildCmd := exec.Command("go", "build", "-o", "veritas_test_binary")
+	buildCmd.Dir = "." // Run in the main package directory
+	if output, err := buildCmd.CombinedOutput(); err != nil {
+		t.Fatalf("Failed to build veritas binary: %v\nOutput: %s", err, string(output))
+	}
+	defer os.Remove("veritas_test_binary")
+
+	// Run the generated binary
+	runCmd := exec.Command("./veritas_test_binary", "-in", inputPath, "-out", outputJSONPath)
+	if output, err := runCmd.CombinedOutput(); err != nil {
+		t.Fatalf("Veritas CLI failed: %v\nOutput: %s", err, string(output))
+	}
+
+	// Read the actual output
+	actualJSON, err := os.ReadFile(outputJSONPath)
+	if err != nil {
+		t.Fatalf("Failed to read output JSON: %v", err)
+	}
+
+	// Define the expected output
+	want := map[string]veritas.ValidationRuleSet{
+		"MockUser": {
+			TypeRules: []string{
+				"self.Age >= 18",
+			},
+			FieldRules: map[string][]string{
+				"Name":  {"size(self.Name) > 0"},
+				"Email": {"size(self.Email) > 0", "self.Email.matches('^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\\\.[a-zA-Z]{2,}$')"},
+			},
+		},
+	}
+
+	// Unmarshal actual JSON to compare with the 'want' map
+	var got map[string]veritas.ValidationRuleSet
+	if err := json.Unmarshal(actualJSON, &got); err != nil {
+		t.Fatalf("Failed to unmarshal actual JSON: %v", err)
+	}
+
+	// The double backslash in the Go string literal for the regex (`\\.`) is preserved
+	// as `\\` by the JSON marshaller. The test's `want` map also has `\\.` in its
+	// string literal, so no transformation is needed for the comparison.
+
+	// Custom comparer to sort slices before comparing.
+	opts := cmp.Options{
+		cmp.Transformer("Sort", func(s []string) []string {
+			sort.Strings(s)
+			return s
+		}),
+	}
+	if diff := cmp.Diff(want, got, opts...); diff != "" {
+		t.Errorf("Generated JSON mismatch (-want +got):\n%s", diff)
+	}
+}

--- a/cmd/veritas/parser_test.go
+++ b/cmd/veritas/parser_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"log/slog"
 	"os"
+	"sort"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -11,7 +12,7 @@ import (
 
 func TestParser(t *testing.T) {
 	t.Run("parse struct with tags and comments", func(t *testing.T) {
-		logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
+		logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
 		p := NewParser(logger)
 
 		want := map[string]veritas.ValidationRuleSet{
@@ -20,18 +21,26 @@ func TestParser(t *testing.T) {
 					"self.Age >= 18",
 				},
 				FieldRules: map[string][]string{
-					"Name":  {"required"},
-					"Email": {"required", "email"},
+					"Name":  {"size(self.Name) > 0"},
+					"Email": {"size(self.Email) > 0", "self.Email.matches('^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\\\.[a-zA-Z]{2,}$')"},
 				},
 			},
 		}
 
+		// Note: The path is relative to the `veritas` package root.
 		got, err := p.Parse("../../testdata/sources/user.go")
 		if err != nil {
 			t.Fatalf("Parse() error = %v, want nil", err)
 		}
 
-		if diff := cmp.Diff(want, got); diff != "" {
+		// Custom comparer to sort slices before comparing, making tests robust against element order changes.
+		opts := cmp.Options{
+			cmp.Transformer("Sort", func(s []string) []string {
+				sort.Strings(s)
+				return s
+			}),
+		}
+		if diff := cmp.Diff(want, got, opts...); diff != "" {
 			t.Errorf("Parse() mismatch (-want +got):\n%s", diff)
 		}
 	})

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,9 @@ require (
 	github.com/antlr4-go/antlr/v4 v4.13.0 // indirect
 	github.com/stoewer/go-strcase v1.3.0 // indirect
 	golang.org/x/exp v0.0.0-20230515195305-f3d0a9c9a5cc // indirect
+	golang.org/x/mod v0.26.0 // indirect
+	golang.org/x/sync v0.16.0 // indirect
+	golang.org/x/tools v0.35.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20240520151616-dc85e6b867a5 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240515191416-fc5f0ca64291 // indirect
 	google.golang.org/protobuf v1.34.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,14 @@ github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKs
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 golang.org/x/exp v0.0.0-20230515195305-f3d0a9c9a5cc h1:mCRnTeVUjcrhlRmO0VK8a6k6Rrf6TF9htwo2pJVSjIU=
 golang.org/x/exp v0.0.0-20230515195305-f3d0a9c9a5cc/go.mod h1:V1LtkGg67GoY2N1AnLN78QLrzxkLyJw7RJb1gzOOz9w=
+golang.org/x/mod v0.26.0 h1:EGMPT//Ezu+ylkCijjPc+f4Aih7sZvaAr+O3EHBxvZg=
+golang.org/x/mod v0.26.0/go.mod h1:/j6NAhSk8iQ723BGAUyoAcn7SlD7s15Dp9Nd/SfeaFQ=
+golang.org/x/sync v0.16.0 h1:ycBJEhp9p4vXvUZNszeOq0kGTPghopOL8q0fq3vstxw=
+golang.org/x/sync v0.16.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
 golang.org/x/text v0.14.0 h1:ScX5w1eTa3QqT8oi6+ziP7dTV1S2+ALU0bI+0zXKWiQ=
 golang.org/x/text v0.14.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=
+golang.org/x/tools v0.35.0 h1:mBffYraMEf7aa0sB+NuKnuCy8qI/9Bughn8dC2Gu5r0=
+golang.org/x/tools v0.35.0/go.mod h1:NKdj5HkL/73byiZSJjqJgKn3ep7KjFkBOkR/Hps3VPw=
 google.golang.org/genproto/googleapis/api v0.0.0-20240520151616-dc85e6b867a5 h1:P8OJ/WCl/Xo4E4zoe4/bifHpSmmKwARqyqE4nW6J2GQ=
 google.golang.org/genproto/googleapis/api v0.0.0-20240520151616-dc85e6b867a5/go.mod h1:RGnPtTG7r4i8sPlNyDeikXF99hMM+hN6QMm4ooG9g2g=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20240515191416-fc5f0ca64291 h1:AgADTJarZTBqgjiUzRgfaBchgYB3/WFTC80GPwsMcRI=


### PR DESCRIPTION
This commit implements the core logic for the `veritas` CLI tool.

- Implement a parser to extract validation rules from struct tags and comments.
- Add support for shorthands like `required` and `email` and convert them to CEL expressions.
- Implement the main CLI logic to parse Go source files and write the extracted rules to a JSON file.
- Add E2E tests for the CLI to ensure it generates correct JSON output.

This completes the tasks outlined in Phase 2 of the TODO list.