### PR TITLE
feat: Implement veritas CLI and tests

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -39,13 +39,13 @@ This document outlines the detailed, phased development plan for the "Veritas" v
     -   [x] 2.2.2: Extract type-level rules from special `// @cel: ...` comments preceding a `struct` definition.
     -   [x] 2.2.3: Implement a mapping from common shorthands (`required`, `nonzero`, `email`, etc.) to their corresponding CEL expressions using type-aware analysis.
 
--   **[ ] 2.3: `veritas` CLI Implementation**
-    -   [ ] 2.3.1: Implement logic to output the extracted rules as a structured JSON file.
-    -   [ ] 2.3.2: Use `slog.Info` for progress reporting and `slog.Debug` for detailed parsing steps.
+-   **[x] 2.3: `veritas` CLI Implementation**
+    -   [x] 2.3.1: Implement logic to output the extracted rules as a structured JSON file.
+    -   [x] 2.3.2: Use `slog.Info` for progress reporting and `slog.Debug` for detailed parsing steps.
 
--   **[ ] 2.4: Static Analysis Tool Testing**
-    -   [ ] 2.4.1: Prepare sample Go source files and their expected JSON output as test data.
-    -   [ ] 2.4.2: Write tests that run the generator and compare the actual output against the expected JSON using `go-cmp/cmp`.
+-   **[x] 2.4: Static Analysis Tool Testing**
+    -   [x] 2.4.1: Prepare sample Go source files and their expected JSON output as test data.
+    -   [x] 2.4.2: Write tests that run the generator and compare the actual output against the expected JSON using `go-cmp/cmp`.
 
 ## Phase 3: Advanced Data Structures Support (v0.3)
 

--- a/cmd/veritas/main_test.go
+++ b/cmd/veritas/main_test.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"encoding/json"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/podhmo/veritas"
+)
+
+func TestRun(t *testing.T) {
+	// Setup: Create a temporary directory for the output file.
+	tmpDir, err := os.MkdirTemp("", "veritas-test-")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// Define input and output paths.
+	inPath := "../../testdata/sources"
+	outFile := filepath.Join(tmpDir, "rules.json")
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	// Execute the run function.
+	if err := run(inPath, outFile, logger); err != nil {
+		t.Fatalf("run() failed: %v", err)
+	}
+
+	// Verify the output file was created.
+	_, err = os.Stat(outFile)
+	if os.IsNotExist(err) {
+		t.Fatalf("run() did not create the output file: %s", outFile)
+	}
+
+	// Verify the content of the output file.
+	gotBytes, err := os.ReadFile(outFile)
+	if err != nil {
+		t.Fatalf("Failed to read output file: %v", err)
+	}
+
+	var got map[string]veritas.ValidationRuleSet
+	if err := json.Unmarshal(gotBytes, &got); err != nil {
+		t.Fatalf("Failed to unmarshal output JSON: %v", err)
+	}
+
+	// Define the expected output.
+	want := map[string]veritas.ValidationRuleSet{
+		"sources.MockUser": {
+			TypeRules: []string{
+				"self.Age >= 18",
+			},
+			FieldRules: map[string][]string{
+				"Name":  {`self != ""`},
+				"Email": {`self != ""`, `self.matches('^[^\\s@]+@[^\\s@]+\\.[^\\s@]+$')`},
+				"ID":    {`self != nil`},
+			},
+		},
+		"sources.MockVariety": {
+			FieldRules: map[string][]string{
+				"Count":    {"self != 0"},
+				"IsActive": {"self"},
+				"Scores":   {"self.size() > 0"},
+				"Metadata": {"self.size() > 0"},
+			},
+		},
+	}
+
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("run() output mismatch (-want +got):\n%s", diff)
+	}
+}


### PR DESCRIPTION
- Implement the `run` function in `cmd/veritas/main.go` to parse Go source files and generate a `rules.json`.
- Add an end-to-end test for the CLI functionality in `cmd/veritas/main_test.go`.
- Update `TODO.md` to mark the CLI implementation and testing tasks as complete.