### PR TITLE
docs: Add project name origin to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ It aims to provide a robust validation framework where rules are derived directl
 - **Type-Safe**: Designed to handle complex, nested data structures, including pointers, slices, and maps, with type-safety in mind.
 - **Modern Go**: Built with Go 1.24, `log/slog` for structured logging, and `go-cmp` for testing.
 
+## Project Name
+
+The name "Veritas" is Latin for "truth." It was chosen to symbolize the library's core function: to verify the "truthfulness" or correctness of data against a defined set of rules.
+
 ## Installation
 
 ```bash


### PR DESCRIPTION
This pull request updates the `README.md` file to include a new section explaining the project name, "Veritas," and its significance. 

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R16-R19): Added a section titled "Project Name" to explain that the name "Veritas" is derived from Latin, meaning "truth," and reflects the library's purpose of verifying data correctness.