### PR TITLE
feat: Add veritas-lint linter skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+veritas-lint

--- a/TODO.md
+++ b/TODO.md
@@ -47,6 +47,24 @@ This document outlines the detailed, phased development plan for the "Veritas" v
     -   [x] 2.4.1: Prepare sample Go source files and their expected JSON output as test data.
     -   [x] 2.4.2: Write tests that run the generator and compare the actual output against the expected JSON using `go-cmp/cmp`.
 
+## Phase 2.5: Linter Development (v0.2.1)
+
+**Goal**: Develop the `veritas-lint` tool to statically check for issues in veritas rule definitions.
+
+-   **[ ] 2.5.1: Initial Linter Setup**
+    -   [x] 2.5.1.1: Create the `cmd/veritas-lint` directory and `main.go`.
+    -   [x] 2.5.1.2: Use `golang.org/x/tools/go/analysis/singlechecker` to create the linter's entry point.
+    -   [x] 2.5.1.3: Create the `lint` package with a basic `analysis.Analyzer` definition.
+-   **[ ] 2.5.2: Rule Loading and Parsing**
+    -   [ ] 2.5.2.1: Implement logic for the linter to find and parse `rules.json` files within the target project.
+    -   [ ] 2.5.2.2: The linter should be able to parse the JSON into `ValidationRuleSet` structs.
+-   **[ ] 2.5.3: Basic Checks**
+    -   [ ] 2.5.3.1: Implement a check to ensure that CEL expressions in rules are syntactically valid.
+    -   [ ] 2.5.3.2: Implement a check to verify that field names in `FieldRules` actually exist in the corresponding struct.
+-   **[ ] 2.5.4: Linter Testing**
+    -   [ ] 2.5.4.1: Create test cases with valid and invalid `rules.json` files.
+    -   [ ] 2.5.4.2: Use `analysistest` to write tests for the linter.
+
 ## Phase 3: Advanced Data Structures Support (v0.3)
 
 **Goal**: Enhance the library to handle complex data structures common in modern Go applications.

--- a/lint/analyzer.go
+++ b/lint/analyzer.go
@@ -1,0 +1,22 @@
+package lint
+
+import (
+	"go/ast"
+	"golang.org/x/tools/go/analysis"
+)
+
+var Analyzer = &analysis.Analyzer{
+	Name: "veritas",
+	Doc:  "veritas is a linter for veritas rules",
+	Run:  run,
+}
+
+func run(pass *analysis.Pass) (interface{}, error) {
+	for _, file := range pass.Files {
+		ast.Inspect(file, func(n ast.Node) bool {
+			// TODO: implement lint logic
+			return true
+		})
+	}
+	return nil, nil
+}


### PR DESCRIPTION
Adds the basic structure for a new linter `veritas-lint` using `singlechecker`.

This includes:
- A `main` package in `cmd/veritas-lint`
- A new `lint` package with a placeholder analyzer
- An updated `TODO.md` with a plan for the linter's development
- A `.gitignore` file to exclude the linter binary