### PR TITLE
fix(lint): correct testdata and want comments

### DIFF
--- a/lint/testdata/src/a/a.go
+++ b/lint/testdata/src/a/a.go
@@ -1,8 +1,6 @@
-package a
+package a // want "invalid type rule for User: ERROR: <input>:1:4: Syntax error: mismatched input '<EOF>' expecting .*"
 
 type User struct { // want "field NonExistentField in rules for User does not exist in struct"
 	Name  string
 	Email string
 }
-
-// want "invalid type rule for User: ERROR: <input>:1:9: Syntax error: mismatched input 'cel' expecting <EOF>"

--- a/lint/testdata/src/a/rules.json
+++ b/lint/testdata/src/a/rules.json
@@ -5,7 +5,7 @@
         "size(self) > 0"
       ],
       "Email": [
-        "self.matches('^[^@]+@[^@]+\\.[^@]+$')"
+  "custom.matches(self, '^[^@]+@[^@]+\\\\.[^@]+$')"
       ],
       "NonExistentField": [
         "self > 0"
@@ -13,7 +13,7 @@
     },
     "typeRules": [
       "self.Name != self.Email",
-      "invalid cel syntax"
+"1 +"
     ]
   }
 }


### PR DESCRIPTION
The analysistest for the veritas-lint was failing due to incorrect CEL syntax in the test `rules.json` and mismatched `want` comments in the test source file `a.go`.

This change corrects the `rules.json` to use `custom.matches` and escapes the dot in the regex properly for JSON. It also updates the `want` comments in `a.go` to match the actual diagnostic messages produced by the linter, allowing the test to pass.