### PR TITLE
feat: Add context.Context to Validator.Validate

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -101,7 +101,7 @@ This document outlines the detailed, phased development plan for the "Veritas" v
 
 -   **[ ] 4.2: Performance and Stabilization**
     -   [ ] 4.2.1: Establish a benchmark suite to identify and optimize performance bottlenecks.
-    -   [ ] 4.2.2: Add `context.Context` to the `Validate` method signature to support timeouts and cancellation.
+    -   [x] 4.2.2: Add `context.Context` to the `Validate` method signature to support timeouts and cancellation.
 
 -   **[ ] 4.3: Documentation and Ecosystem**
     -   [ ] 4.3.1: Create a comprehensive documentation website detailing installation, usage, CLI commands, and all supported rules/shorthands.


### PR DESCRIPTION
This change introduces `context.Context` to the `Validate` method in the validator, allowing for timeouts and cancellations during the validation process.

The `Validate` and `validateRecursive` methods now accept a `context.Context` as their first argument. The `cel-go` program evaluation is now done using `prog.ContextEval(ctx, ...)` instead of `prog.Eval(...)`.

Additionally, cancellation checks have been added to the `validateRecursive` function to stop validation promptly if the context is cancelled.

The test suite has been updated to include tests for context cancellation and timeouts, ensuring the new functionality works as expected.