### PR TITLE
feat: add github actions workflow for benchmark

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,18 @@
+name: Manual Benchmark
+
+on:
+  workflow_dispatch:
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.21'
+      - name: Install dependencies
+        run: go mod download
+      - name: Run benchmark
+        run: go test -bench=. ./...

--- a/TODO.md
+++ b/TODO.md
@@ -100,7 +100,7 @@ This document outlines the detailed, phased development plan for the "Veritas" v
         -   **Note**: The `Validator` now correctly handles pointer values within generic types (e.g., `Box[*string]`, `Box[*Item]`) by dereferencing them before evaluation. If the dereferenced value is a struct with a registered `TypeAdapter`, it's converted to a `map[string]any` to prevent `cel-go`'s `unsupported conversion` errors.
 
 -   **[ ] 4.2: Performance and Stabilization**
-    -   [ ] 4.2.1: Establish a benchmark suite to identify and optimize performance bottlenecks.
+    -   [x] 4.2.1: Establish a benchmark suite to identify and optimize performance bottlenecks.
     -   [x] 4.2.2: Add `context.Context` to the `Validate` method signature to support timeouts and cancellation.
 
 -   **[ ] 4.3: Documentation and Ecosystem**


### PR DESCRIPTION
This pull request introduces a benchmark suite for the `Validator` to measure and optimize its performance. Key changes include the addition of a GitHub Actions workflow for manual benchmarking, updates to the project roadmap, and new benchmark tests in the codebase.

### Benchmarking Enhancements:

* [`.github/workflows/benchmark.yml`](diffhunk://#diff-aacbd0338bcf598920c120b69adaba2672acc7ea314cfca0f792bebe5fe2acd0R1-R18): Added a new GitHub Actions workflow named "Manual Benchmark" that can be triggered manually. It sets up a Go environment, installs dependencies, and runs benchmarks using `go test -bench`.
* [`validator_test.go`](diffhunk://#diff-1a24049b83249f1a123190657957d3dba688a2343c842cdc947e282d6d6d25a6R499-R594): Introduced a series of benchmark tests for the `Validator` to measure performance under different scenarios, including with and without caching. A helper function, `setupBenchmark`, was also added to standardize the setup process for these tests.

### Documentation Updates:

* [`TODO.md`](diffhunk://#diff-5c6a1301c6b59b30a040d747d065e861d3dd98bde0e5a4356d92d594e9835986L103-R103): Marked the task for establishing a benchmark suite as completed in the project roadmap under section 4.2.1.