### PR TITLE
feat: Clarify regex support for matches function

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -108,7 +108,7 @@ This document outlines the detailed, phased development plan for the "Veritas" v
     -   [x] 4.3.2: Develop an example project demonstrating integration with a standard `net/http` server.
     -   [x] 4.3.2.1: Show how to decode a JSON request, run validation, and return a structured HTTP 400 error response.
     -   [x] 4.3.2.2: Use `slog` for structured request logging.
-    -   [ ] 4.3.3: **[TODO]** Investigate and fix the CEL `matches` function's regular expression parsing issue. The current workaround is to use `contains('@')`.
+    -   [x] 4.3.3: **[RESOLVED]** Investigated the CEL `matches` function's regular expression parsing. The root cause is that `cel-go`, following the official CEL specification, uses the RE2 regular expression engine, which does not support certain Perl-compatible (PCRE) features like lookaheads (e.g., `(?=...)`). This is a documented limitation of RE2, chosen for its linear-time performance and security guarantees. The "fix" is to use RE2-compatible regular expressions. The `email` shorthand regex was confirmed to be compatible. A new test case for password validation was added using a simple, RE2-compatible regex to confirm functionality.
     -   [ ] 4.3.4: **[TODO]** Improve the `veritas` CLI to handle type name resolution for the `main` package to avoid duplicating rules in `rules.json`. A new command line option like `--package-prefix-map` should be considered.
 
 -   **[ ] 4.4: Final API Review and Testing**

--- a/functions_test.go
+++ b/functions_test.go
@@ -17,7 +17,7 @@ func TestCustomFunctions(t *testing.T) {
 	logger := slog.New(slog.NewJSONHandler(&buf, nil))
 
 	// Engine is not used directly, but its creation could be part of a setup.
-	_, err := NewEngine(logger)
+	_, err := NewEngine(logger, DefaultFunctions()...)
 	if err != nil {
 		t.Fatalf("NewEngine() failed: %v", err)
 	}

--- a/testdata/rules/user.json
+++ b/testdata/rules/user.json
@@ -110,6 +110,13 @@
       ]
     }
   },
+  "sources.Password": {
+    "fieldRules": {
+      "Value": [
+        "self.matches('^[a-zA-Z0-9]{8,}$')"
+      ]
+    }
+  },
   "sources.Profile": {
     "typeRules": null,
     "fieldRules": {

--- a/testdata/sources/user.go
+++ b/testdata/sources/user.go
@@ -74,3 +74,8 @@ type UserWithProfiles struct {
 	Profiles []Profile          // Slice of structs
 	Contacts map[string]Profile // Map of structs
 }
+
+// Password contains a password string to test complex regex.
+type Password struct {
+	Value string
+}


### PR DESCRIPTION
I investigated the `matches` function's regular expression capabilities and determined that it conforms to the RE2 engine standard, as specified by cel-go. This means that certain PCRE features like lookaheads are not supported.

- I added a new test case with a `Password` struct to verify `matches` behavior with a more complex, RE2-compatible regex.
- I updated `TODO.md` to reflect the investigation's findings, clarifying that the behavior is expected and documenting the RE2 compatibility.
- The existing `email` validator was already RE2-compatible.