### PR TITLE
feat: Implement Go code generation for validation rules

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -119,14 +119,14 @@ This document outlines the detailed, phased development plan for the "Veritas" v
 
 **Goal**: Implement Go code generation as the primary, recommended method for rule management, improving type-safety, performance, and developer experience.
 
--   **[ ] 5.1: Enhance CLI for Go Code Generation**
-    -   [ ] 5.1.1: Add a `--format=go` flag to the `veritas` CLI to enable Go source code output. The default will remain `--format=json` for backward compatibility in v1.x.
-    -   [ ] 5.1.2: Implement the core logic to generate a Go source file (e.g., `generated_rules.go`) containing `veritas.ValidationRuleSet` definitions.
-    -   [ ] 5.1.3: The generated file will use an `init()` function to register नियम sets into a global registry.
+-   **[x] 5.1: Enhance CLI for Go Code Generation**
+    -   [x] 5.1.1: Add a `--format=go` flag to the `veritas` CLI to enable Go source code output. The default will remain `--format=json` for backward compatibility in v1.x.
+    -   [x] 5.1.2: Implement the core logic to generate a Go source file (e.g., `generated_rules.go`) containing `veritas.ValidationRuleSet` definitions.
+    -   [x] 5.1.3: The generated file will use an `init()` function to register rule sets into a global registry.
 
--   **[ ] 5.2: Implement Static Rule Provider**
-    -   [ ] 5.2.1: Create a global rule registry within the `veritas` library that can be populated by the `init()` functions of generated code.
-    -   [ ] 5.2.2: Update `veritas.NewValidator()` to be able to use this global registry by default, removing the need to pass a `RuleProvider` for the common use-case.
+-   **[x] 5.2: Implement Static Rule Provider**
+    -   [x] 5.2.1: Create a global rule registry within the `veritas` library that can be populated by the `init()` functions of generated code.
+    -   [x] 5.2.2: Update `veritas.NewValidator()` to be able to use this global registry by default, removing the need to pass a `RuleProvider` for the common use-case.
     -   [ ] 5.2.3: The existing `JSONRuleProvider` will be kept for users who need dynamic rule loading.
 
 -   **[ ] 5.3: Update Documentation and Tooling**

--- a/cmd/veritas/gocode_generator.go
+++ b/cmd/veritas/gocode_generator.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"go/format"
+	"io"
+	"log/slog"
+	"sort"
+
+	"github.com/podhmo/veritas"
+)
+
+// GoCodeGenerator generates Go code for validation rule sets.
+type GoCodeGenerator struct {
+	logger *slog.Logger
+	buf    *bytes.Buffer
+}
+
+// NewGoCodeGenerator creates a new GoCodeGenerator.
+func NewGoCodeGenerator(logger *slog.Logger) *GoCodeGenerator {
+	return &GoCodeGenerator{
+		logger: logger,
+		buf:    new(bytes.Buffer),
+	}
+}
+
+// Generate writes the Go code for the given rule sets to the writer.
+func (g *GoCodeGenerator) Generate(pkgName string, ruleSets map[string]veritas.ValidationRuleSet, w io.Writer) error {
+	g.buf.Reset()
+
+	// 1. Print package and imports
+	g.printf("package %s\n\n", pkgName)
+	g.printf("import (\n")
+	g.printf("\t\"github.com/podhmo/veritas\"\n")
+	g.printf(")\n\n")
+
+	// 2. Print init function
+	g.printf("func init() {\n")
+	// Sort keys for deterministic output
+	keys := make([]string, 0, len(ruleSets))
+	for k := range ruleSets {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	for _, key := range keys {
+		ruleSet := ruleSets[key]
+		g.printf("\tveritas.Register(\"%s\", veritas.ValidationRuleSet{\n", key)
+		if len(ruleSet.TypeRules) > 0 {
+			g.printf("\t\tTypeRules: []string{\n")
+			for _, rule := range ruleSet.TypeRules {
+				g.printf("\t\t\t`%s`,\n", rule)
+			}
+			g.printf("\t\t},\n")
+		}
+		if len(ruleSet.FieldRules) > 0 {
+			g.printf("\t\tFieldRules: map[string][]string{\n")
+			fieldKeys := make([]string, 0, len(ruleSet.FieldRules))
+			for fk := range ruleSet.FieldRules {
+				fieldKeys = append(fieldKeys, fk)
+			}
+			sort.Strings(fieldKeys)
+			for _, fk := range fieldKeys {
+				g.printf("\t\t\t\"%s\": {\n", fk)
+				for _, rule := range ruleSet.FieldRules[fk] {
+					g.printf("\t\t\t\t`%s`,\n", rule)
+				}
+				g.printf("\t\t\t},\n")
+			}
+			g.printf("\t\t},\n")
+		}
+		g.printf("\t})\n")
+	}
+	g.printf("}\n")
+
+	// 3. Format and write the output
+	formatted, err := format.Source(g.buf.Bytes())
+	if err != nil {
+		return fmt.Errorf("failed to format generated go code: %w\nraw code:\n%s", err, g.buf.String())
+	}
+
+	_, err = w.Write(formatted)
+	return err
+}
+
+func (g *GoCodeGenerator) printf(format string, args ...interface{}) {
+	fmt.Fprintf(g.buf, format, args...)
+}

--- a/cmd/veritas/gocode_generator_test.go
+++ b/cmd/veritas/gocode_generator_test.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"bytes"
+	"log/slog"
+	"os"
+	"testing"
+
+	"github.com/podhmo/veritas"
+)
+
+func TestGoCodeGenerator(t *testing.T) {
+	logger := slog.New(slog.NewJSONHandler(os.Stderr, nil))
+	generator := NewGoCodeGenerator(logger)
+
+	ruleSets := map[string]veritas.ValidationRuleSet{
+		"main.User": {
+			TypeRules: []string{"self.Name != ''"},
+			FieldRules: map[string][]string{
+				"Email": {"self.matches('^[^@]+@[^@]+$')"},
+				"Age":   {"self > 18"},
+			},
+		},
+		"main.Post": {
+			FieldRules: map[string][]string{
+				"Title":   {"self != ''"},
+				"Content": {"self.size() > 10"},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	err := generator.Generate("main", ruleSets, &buf)
+	if err != nil {
+		t.Fatalf("Generate() error = %v", err)
+	}
+
+	// For now, we'll just check that the output is not empty.
+	// A more robust test would parse the generated Go code and verify its structure.
+	if buf.Len() == 0 {
+		t.Errorf("Generate() output is empty")
+	}
+
+	// You can uncomment this to see the generated code during testing.
+	// t.Log(buf.String())
+}

--- a/cmd/veritas/main_test.go
+++ b/cmd/veritas/main_test.go
@@ -28,7 +28,7 @@ func TestRun(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
 
 	// Execute the main logic.
-	if err := run(inPath, outFile, logger); err != nil {
+	if err := run(inPath, outFile, "json", logger); err != nil {
 		t.Fatalf("run() error = %v", err)
 	}
 
@@ -148,7 +148,7 @@ func TestRun_mainPackage(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
 
 	// Execute the main logic.
-	if err := run(inPath, outFile, logger); err != nil {
+	if err := run(inPath, outFile, "json", logger); err != nil {
 		t.Fatalf("run() error = %v", err)
 	}
 

--- a/registry.go
+++ b/registry.go
@@ -1,0 +1,52 @@
+package veritas
+
+import "sync"
+
+var (
+	globalRegistry     = make(map[string]ValidationRuleSet)
+	globalRegistryLock sync.RWMutex
+)
+
+// Register adds a validation rule set to the global registry.
+// This function is intended to be called from init() functions in generated code.
+func Register(typeName string, ruleSet ValidationRuleSet) {
+	globalRegistryLock.Lock()
+	defer globalRegistryLock.Unlock()
+	globalRegistry[typeName] = ruleSet
+}
+
+// Unregister removes a validation rule set from the global registry.
+// This is mainly useful for testing purposes.
+func Unregister(typeName string) {
+	globalRegistryLock.Lock()
+	defer globalRegistryLock.Unlock()
+	delete(globalRegistry, typeName)
+}
+
+// UnregisterAll removes all validation rule sets from the global registry.
+// This is mainly useful for testing purposes.
+func UnregisterAll() {
+	globalRegistryLock.Lock()
+	defer globalRegistryLock.Unlock()
+	globalRegistry = make(map[string]ValidationRuleSet)
+}
+
+// NewRuleProviderFromRegistry creates a new RuleProvider that uses the global registry.
+func NewRuleProviderFromRegistry() RuleProvider {
+	return &registryProvider{}
+}
+
+type registryProvider struct{}
+
+// GetRuleSets returns a copy of the global registry.
+func (p *registryProvider) GetRuleSets() (map[string]ValidationRuleSet, error) {
+	globalRegistryLock.RLock()
+	defer globalRegistryLock.RUnlock()
+
+	// Return a copy to prevent race conditions if the caller modifies the map.
+	rules := make(map[string]ValidationRuleSet, len(globalRegistry))
+	for k, v := range globalRegistry {
+		rules[k] = v
+	}
+	return rules, nil
+}

--- a/validator.go
+++ b/validator.go
@@ -30,6 +30,9 @@ type Validator struct {
 // NewValidator creates a new validator.
 // It requires a map of type names to TypeAdapter functions to handle object-to-map conversion.
 func NewValidator(engine *Engine, provider RuleProvider, logger *slog.Logger, adapters map[string]TypeAdapter) (*Validator, error) {
+	if provider == nil {
+		provider = NewRuleProviderFromRegistry()
+	}
 	rules, err := provider.GetRuleSets()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get rule sets: %w", err)


### PR DESCRIPTION
This commit introduces the Go code generation feature, which allows you to generate Go source code for your validation rules instead of relying on JSON files at runtime.

Key changes:
- Added a `--format=go` flag to the `veritas` CLI.
- Implemented a `GoCodeGenerator` to create Go source files from parsed rules.
- Created a global rule registry that is populated by `init()` functions in the generated code.
- Updated the `Validator` to use the global registry by default.
- Added unit tests for the new functionality.