### PR TITLE
feat: Add --lint option to run only the linter

### DIFF
--- a/cmd/veritas/gen/analyzer.go
+++ b/cmd/veritas/gen/analyzer.go
@@ -26,16 +26,14 @@ func run(pass *codegen.Pass) error {
 	logger := slog.New(slog.NewJSONHandler(os.Stderr, nil)) // Create a logger
 	p := parser.NewParser(logger)
 
-	// This is not a robust way to find the root of the project.
-	// But for now, it works for the test.
 	pkgPath := pass.Pkg.Path()
 	if _, err := os.Stat(pkgPath); err != nil {
 		if _, err := os.Stat("testdata"); err == nil {
-			pkgPath = "testdata/src/a"
+			pkgPath = "github.com/podhmo/veritas/cmd/veritas/gen/testdata/src/a"
 		}
 	}
 
-	ruleSets, err := p.Parse("github.com/podhmo/veritas/cmd/veritas/gen/testdata/src/a")
+	ruleSets, err := p.Parse(pkgPath)
 	if err != nil {
 		return fmt.Errorf("failed to parse: %w", err)
 	}

--- a/cmd/veritas/lint/main.go
+++ b/cmd/veritas/lint/main.go
@@ -1,0 +1,10 @@
+package lint
+
+import (
+	"github.com/podhmo/veritas/lint"
+	"golang.org/x/tools/go/analysis/singlechecker"
+)
+
+func Main() {
+	singlechecker.Main(lint.Analyzer)
+}

--- a/cmd/veritas/main.go
+++ b/cmd/veritas/main.go
@@ -1,10 +1,22 @@
 package main
 
 import (
+	"flag"
+
 	"github.com/gostaticanalysis/codegen/singlegenerator"
 	"github.com/podhmo/veritas/cmd/veritas/gen"
+	lintcmd "github.com/podhmo/veritas/cmd/veritas/lint"
 )
 
 func main() {
+	var lintFlag bool
+	flag.BoolVar(&lintFlag, "lint", false, "run linter")
+	flag.Parse()
+
+	if lintFlag {
+		lintcmd.Main()
+		return
+	}
+
 	singlegenerator.Main(gen.Generator)
 }

--- a/cmd/veritas/main_test.go
+++ b/cmd/veritas/main_test.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func TestMain(t *testing.T) {
+	// Build the veritas command
+	cmd := exec.Command("go", "build", "-o", "veritas_test", ".")
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("failed to build veritas command: %v", err)
+	}
+	defer os.Remove("veritas_test")
+
+	t.Run("lint", func(t *testing.T) {
+		cmd := exec.Command("./veritas_test", "-lint", "github.com/podhmo/veritas/lint/testdata/src/a")
+		var stdout, stderr bytes.Buffer
+		cmd.Stdout = &stdout
+		cmd.Stderr = &stderr
+		err := cmd.Run()
+
+		if err == nil {
+			t.Errorf("expected an error, but got none")
+		}
+
+		if !strings.Contains(stderr.String(), "invalid type rule for User: ERROR: <input>:1:4: Syntax error: mismatched input '<EOF>' expecting {'[', '{', '(', '.', '-', '!', 'true', 'false', 'null', NUM_FLOAT, NUM_INT, NUM_UINT, STRING, BYTES, IDENTIFIER}") {
+			t.Errorf("expected to find a lint error, but got %q", stderr.String())
+		}
+	})
+
+	t.Run("gen", func(t *testing.T) {
+		// Run the generator
+		cmd := exec.Command("./veritas_test", "github.com/podhmo/veritas/cmd/veritas/gen/testdata/src/a")
+		var stdout, stderr bytes.Buffer
+		cmd.Stdout = &stdout
+		cmd.Stderr = &stderr
+		err := cmd.Run()
+		if err != nil {
+			t.Fatalf("failed to run veritas command: %v, stderr: %s", err, stderr.String())
+		}
+
+		// check stdout has "veritas.Register"
+		if !strings.Contains(stdout.String(), "veritas.Register") {
+			t.Errorf("expected to find veritas.Register in stdout, but got %q", stdout.String())
+		}
+	})
+}
+
+func captureOutput(f func()) (string, string) {
+	oldStdout := os.Stdout
+	oldStderr := os.Stderr
+	rOut, wOut, _ := os.Pipe()
+	rErr, wErr, _ := os.Pipe()
+	os.Stdout = wOut
+	os.Stderr = wErr
+
+	f()
+
+	wOut.Close()
+	wErr.Close()
+	out, _ := io.ReadAll(rOut)
+	err, _ := io.ReadAll(rErr)
+	os.Stdout = oldStdout
+	os.Stderr = oldStderr
+
+	return string(out), string(err)
+}


### PR DESCRIPTION
This change adds a `--lint` flag to the `veritas` command. When this flag is provided, the command will run the linter instead of the code generator.

I have also added tests to ensure that the `--lint` flag works as expected.