### PR TITLE
feat: create comprehensive documentation website

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -104,7 +104,7 @@ This document outlines the detailed, phased development plan for the "Veritas" v
     -   [x] 4.2.2: Add `context.Context` to the `Validate` method signature to support timeouts and cancellation.
 
 -   **[x] 4.3: Documentation and Ecosystem**
-    -   [ ] 4.3.1: Create a comprehensive documentation website detailing installation, usage, CLI commands, and all supported rules/shorthands.
+    -   [x] 4.3.1: Create a comprehensive documentation website detailing installation, usage, CLI commands, and all supported rules/shorthands.
     -   [x] 4.3.2: Develop an example project demonstrating integration with a standard `net/http` server.
     -   [x] 4.3.2.1: Show how to decode a JSON request, run validation, and return a structured HTTP 400 error response.
     -   [x] 4.3.2.2: Use `slog` for structured request logging.

--- a/docs/website/advanced.md
+++ b/docs/website/advanced.md
@@ -1,0 +1,74 @@
+# Advanced Topics
+
+## Custom CEL Functions
+
+Veritas provides a set of default custom functions that can be used in your validation rules.
+
+### `strings.ToUpper(string) string`
+
+Converts a string to uppercase.
+
+**Example:**
+```go
+// @cel: strings.ToUpper(self.CountryCode) == "US"
+type Address struct {
+    CountryCode string `validate:"required"`
+}
+```
+
+### `custom.matches(string, string) bool`
+
+Performs a regular expression match. This provides an alternative to the built-in `matches` function and uses Go's `regexp` engine.
+
+**Example:**
+```go
+type User struct {
+    Username string `validate:"cel:custom.matches(self, '^[a-z0-9_]+$')"`
+}
+```
+
+## Adding Your Own Custom Functions
+
+You can extend Veritas with your own custom functions by creating a `cel.EnvOption`.
+
+1.  **Define your function:**
+
+    ```go
+    import (
+        "github.com/google/cel-go/cel"
+        "github.com/google/cel-go/common/types"
+        "github.com/google/cel-go/common/types/ref"
+    )
+
+    func isAwesome() cel.EnvOption {
+        return cel.Function("isAwesome",
+            cel.Overload("is_awesome_string",
+                []*cel.Type{cel.StringType},
+                cel.BoolType,
+                cel.UnaryBinding(func(s ref.Val) ref.Val {
+                    return types.Bool(s.(types.String) == "veritas")
+                }),
+            ),
+        )
+    }
+    ```
+
+2.  **Create your validator with the custom function:**
+
+    ```go
+    import "github.com/podhmo/veritas"
+
+    // Create a new engine with your function
+    engine, err := veritas.NewEngine(isAwesome())
+    if err != nil {
+        // handle error
+    }
+
+    // Create a validator using the custom engine
+    validator, err := veritas.NewValidatorWithEngine(engine)
+    if err != nil {
+        // handle error
+    }
+
+    // Now you can use the isAwesome function in your rules
+    ```

--- a/docs/website/cli.md
+++ b/docs/website/cli.md
@@ -1,0 +1,62 @@
+# CLI Reference
+
+The `veritas` command-line tool has two main functions: generating validation code and linting your validation rules.
+
+## Code Generation (`veritas`)
+
+This is the default mode of the `veritas` tool. It scans your Go source files for struct annotations and generates Go code containing your validation rules.
+
+### Usage
+
+The generator is typically run via `go generate`.
+
+```go
+//go:generate go run github.com/podhmo/veritas/cmd/veritas [flags]
+```
+
+### Flags
+
+-   `-gen-type <TypeName>`: **(Required)** The name of the struct type to generate rules for.
+-   `-out-name <filename.go>`: **(Required)** The name of the Go file to be generated.
+
+### Example
+
+```go
+// file: models/user.go
+package models
+
+//go:generate go run github.com/podhmo/veritas/cmd/veritas -gen-type=User -out-name=veritas_gen.go
+
+type User struct {
+    // ...
+}
+```
+
+Running `go generate ./...` in your project will execute this command, creating `veritas_gen.go` in the `models` package.
+
+## Linting (`veritas -lint`)
+
+The linter statically checks your `rules.json` files for common errors.
+
+### Usage
+
+```bash
+veritas -lint [packages]
+```
+
+The linter recursively finds and analyzes `rules.json` files in the specified packages. If no packages are provided, it defaults to the current directory (`.`).
+
+### Checks
+
+The linter performs the following checks:
+
+1.  **Valid CEL Syntax**: Ensures that all `TypeRules` and `FieldRules` are syntactically correct CEL expressions.
+2.  **Field Existence**: Verifies that every field specified in a `FieldRules` map actually exists in the corresponding Go struct.
+
+### Example
+
+To run the linter on your entire project:
+
+```bash
+go run github.com/podhmo/veritas/cmd/veritas -lint ./...
+```

--- a/docs/website/getting-started.md
+++ b/docs/website/getting-started.md
@@ -1,0 +1,75 @@
+# Getting Started
+
+The recommended approach is to use Go code generation for a type-safe, high-performance validation experience.
+
+1.  **Annotate your structs:**
+
+    Add validation rules using struct tags and special `// @cel:` comments.
+
+    ```go
+    // file: models/user.go
+    package models
+
+    //go:generate go run github.com/podhmo/veritas/cmd/veritas -gen-type=User -out-name=veritas_gen.go
+
+    // @cel: self.Password == self.PasswordConfirm
+    type User struct {
+        Name     string `validate:"required,cel:self.size() < 50"`
+        Email    string `validate:"required,email"`
+        Age      int    `validate:"cel:self >= 18"`
+        Password string `validate:"required,cel:self.size() >= 10"`
+        PasswordConfirm string `validate:"required"`
+    }
+    ```
+
+2.  **Generate validation code:**
+
+    Use `go generate` to run the `veritas` tool. It will scan your struct and create a `veritas_gen.go` file in the same package.
+
+    ```bash
+    go generate ./...
+    ```
+
+    The generated file will contain an `init()` function that automatically registers your validation rules with the veritas library.
+
+3.  **Use the validator in your application:**
+
+    The validator can now be created without any special configuration. The rules are available globally.
+
+    ```go
+    package main
+
+    import (
+        "context"
+        "fmt"
+        "log"
+
+        "github.com/podhmo/veritas"
+        "your-project/models" // Import the package with your models
+    )
+
+    func main() {
+        // Create a new validator.
+        // Rules are automatically loaded from the generated code.
+        validator, err := veritas.NewValidator()
+        if err != nil {
+            log.Fatalf("Failed to create validator: %v", err)
+        }
+
+        // Create a user object to validate
+        user := models.User{
+            Name:            "Test User",
+            Email:           "test@example.com",
+            Age:             30,
+            Password:        "password123",
+            PasswordConfirm: "password123",
+        }
+
+        // Validate the object
+        if err := validator.Validate(context.Background(), user); err != nil {
+            fmt.Printf("Validation failed: %v\n", err)
+        } else {
+            fmt.Println("Validation successful!")
+        }
+    }
+    ```

--- a/docs/website/index.md
+++ b/docs/website/index.md
@@ -1,0 +1,13 @@
+# Veritas Documentation
+
+Welcome to the official documentation for Veritas, a dynamic, type-safe, and extensible validation library for Go.
+
+Veritas helps you ensure your data is correct and conforms to your business rules by deriving validation logic directly from your Go source code.
+
+## Table of Contents
+
+*   **[Getting Started](./getting-started.md)**: A comprehensive guide to get you up and running with Veritas.
+*   **[Installation](./installation.md)**: How to install the Veritas library and CLI tool.
+*   **[CLI Reference](./cli.md)**: Detailed documentation for the `veritas` command-line interface.
+*   **[Rules Reference](./rules.md)**: A complete reference of all built-in validation rules, shorthands, and keywords.
+*   **[Advanced Topics](./advanced.md)**: Learn about custom functions and other advanced features.

--- a/docs/website/installation.md
+++ b/docs/website/installation.md
@@ -1,0 +1,11 @@
+# Installation
+
+To install Veritas, use `go get`:
+
+```bash
+go get github.com/podhmo/veritas
+```
+
+## Requirements
+
+- Go 1.24 or later.

--- a/docs/website/rules.md
+++ b/docs/website/rules.md
@@ -1,0 +1,67 @@
+# Rules Reference
+
+Veritas uses struct tags to define validation rules. The `validate` tag contains a comma-separated list of rules to be applied to a field.
+
+```go
+type User struct {
+    Name  string `validate:"required,cel:self.size() < 50"`
+    Email string `validate:"required,email"`
+    Age   int    `validate:"cel:self >= 18"`
+}
+```
+
+## Type-Level Rules
+
+You can also define rules that apply to the entire struct using a special `// @cel:` comment. This is useful for validation that involves multiple fields.
+
+```go
+// @cel: self.Password == self.PasswordConfirm
+type User struct {
+    Password        string `validate:"required"`
+    PasswordConfirm string `validate:"required"`
+}
+```
+
+## Field-Level Rules
+
+### Shorthands
+
+Veritas provides several shorthands for common validation scenarios.
+
+| Shorthand  | Description                                                                                             | Applicable Types                        |
+| :--------- | :------------------------------------------------------------------------------------------------------ | :-------------------------------------- |
+| `required` | The value must not be the zero value for its type (e.g., not `""`, not `nil`, not an empty slice/map). | `string`, pointers, slices, maps        |
+| `nonzero`  | Similar to `required`, but also asserts `true` for booleans.                                            | `string`, numeric types, pointers, bool |
+| `email`    | The string must match a basic email format.                                                             | `string`                                |
+
+### Raw CEL Expressions
+
+For more complex validation, you can use a raw CEL expression with the `cel:` prefix. The field's value is available as the `self` variable.
+
+```go
+type Product struct {
+    // self refers to the Price field
+    Price float64 `validate:"cel:self > 0.0 && self < 1000.0"`
+
+    // self refers to the SKU field
+    SKU   string  `validate:"cel:self.startsWith('PROD-')"`
+}
+```
+
+### Collection Rules
+
+To validate the elements of slices or maps, you can use the `dive`, `keys`, and `values` keywords.
+
+| Keyword  | Description                                        | Example                                               |
+| :------- | :------------------------------------------------- | :---------------------------------------------------- |
+| `dive`   | Applies rules to each element of a slice.          | `validate:"dive,required"` (each element must be set) |
+| `keys`   | Applies rules to each key of a map.                | `validate:"keys,cel:self.size() > 3"` (each key > 3 chars) |
+| `values` | Applies rules to each value of a map.              | `validate:"values,nonzero"` (each value must be non-zero) |
+
+These can be combined with other rules. For example, to validate a slice of emails where each email must also be under 64 characters:
+
+```go
+type UserList struct {
+    Emails []string `validate:"dive,email,cel:self.size() < 64"`
+}
+```


### PR DESCRIPTION
This commit adds a new documentation website under the `docs/website` directory. The website provides comprehensive information on installation, getting started, CLI usage, validation rules, and advanced topics.

The content was created by consolidating and expanding upon the existing README and other documentation files.