### PR TITLE
docs: add CEL cheatsheet and links to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,8 @@ For more dynamic environments, you can load validation rules from a JSON file.
 
 For more detailed information, please see the [documentation website](docs/website/index.md).
 
+For a quick reference of common CEL expressions, see the [**CEL Cheatsheet**](docs/website/cel-cheatsheet.md). For a complete guide, please refer to the official [**CEL language definition**](https://github.com/google/cel-spec/blob/master/doc/langdef.md).
+
 ## Contributing
 
 We welcome contributions! Please follow these steps to contribute:

--- a/cmd/veritas/gen/testdata/src/a/a.go
+++ b/cmd/veritas/gen/testdata/src/a/a.go
@@ -3,6 +3,6 @@ package a
 // @cel-type: User
 // @cel: self.Email != ""
 type User struct {
-	Name string `validate:"required"`
+	Name  string `validate:"required"`
 	Email string `validate:"email"`
 }

--- a/docs/website/cel-cheatsheet.md
+++ b/docs/website/cel-cheatsheet.md
@@ -1,0 +1,73 @@
+# CEL Cheatsheet
+
+This page provides a quick reference for common expressions and functions available in the Common Expression Language (CEL). For a complete guide, please refer to the official [CEL language definition](https://github.com/google/cel-spec/blob/master/doc/langdef.md).
+
+## Basic Operators
+
+| Operator | Description        | Example                             |
+| -------- | ------------------ | ----------------------------------- |
+| `==`     | Equality           | `self.Status == "active"`           |
+| `!=`     | Inequality         | `self.Role != "admin"`              |
+| `>`      | Greater than       | `self.Age > 18`                     |
+| `>=`     | Greater or equal   | `self.Price >= 0`                   |
+| `<`      | Less than          | `self.Attempts < 5`                 |
+| `<=`     | Less or equal      | `self.Score <= 100`                 |
+| `&&`     | Logical AND        | `self.Enabled && self.Visible`      |
+| `||`     | Logical OR         | `self.IsAdmin || self.IsOwner`      |
+| `!`      | Logical NOT        | `!self.IsExpired`                   |
+| `in`     | Membership         | `self.Role in ["editor", "viewer"]` |
+
+## String Functions
+
+| Function      | Description                               | Example                                  |
+| ------------- | ----------------------------------------- | ---------------------------------------- |
+| `size()`      | Returns the length of the string.         | `self.size() < 20`                       |
+| `startsWith()`| Checks if a string starts with a prefix.  | `self.startsWith("user_")`               |
+| `endsWith()`  | Checks if a string ends with a suffix.    | `self.endsWith(".jpg")`                  |
+| `contains()`  | Checks if a string contains a substring.  | `self.contains("@")`                     |
+| `matches()`   | Checks if a string matches a regex.       | `self.matches("^[a-zA-Z0-9]+$")`         |
+
+## List Functions
+
+| Function | Description                               | Example                               |
+| -------- | ----------------------------------------- | ------------------------------------- |
+| `size()` | Returns the number of elements in a list. | `self.size() > 0`                     |
+| `[]`     | Access an element by index.               | `self[0] == "first"`                  |
+| `in`     | Check for presence of an element.         | `"admin" in self.Roles`               |
+
+## Map Functions
+
+| Function | Description                        | Example                           |
+| -------- | ---------------------------------- | --------------------------------- |
+| `size()` | Returns the number of keys in a map. | `size(self.Attributes) > 0`       |
+| `in`     | Check for presence of a key.       | `"id" in self.Metadata`           |
+| `[]`     | Access a value by key.             | `self.Metadata["version"] == "v1"`|
+
+## Special Keywords
+
+- `self`: Refers to the field or object being validated.
+
+## Type-specific Examples
+
+### Structs
+
+When validating a struct, `self` refers to the struct instance. You can access its fields using dot notation.
+
+```go
+// @cel: self.Password == self.PasswordConfirm
+type User struct {
+    Password        string `validate:"required"`
+    PasswordConfirm string `validate:"required"`
+}
+```
+
+### Fields
+
+When using `validate` tags, `self` refers to the field's value.
+
+```go
+type Product struct {
+    Name  string `validate:"required,cel:self.size() < 50"`
+    Price int    `validate:"cel:self > 0"`
+}
+```

--- a/docs/website/index.md
+++ b/docs/website/index.md
@@ -10,4 +10,9 @@ Veritas helps you ensure your data is correct and conforms to your business rule
 *   **[Installation](./installation.md)**: How to install the Veritas library and CLI tool.
 *   **[CLI Reference](./cli.md)**: Detailed documentation for the `veritas` command-line interface.
 *   **[Rules Reference](./rules.md)**: A complete reference of all built-in validation rules, shorthands, and keywords.
+*   **[CEL Cheatsheet](./cel-cheatsheet.md)**: A quick reference for common CEL expressions.
 *   **[Advanced Topics](./advanced.md)**: Learn about custom functions and other advanced features.
+
+---
+
+For more in-depth information about CEL, please refer to the official [**CEL language definition**](https://github.com/google/cel-spec/blob/master/doc/langdef.md).


### PR DESCRIPTION
Adds a new CEL cheatsheet to the documentation website, providing a quick reference for common expressions and functions.

Also, adds links to the official CEL language definition and the new cheatsheet in the README.md and the main documentation index.