### PR TITLE
feat: Use go:embed in examples/http-server

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -136,3 +136,11 @@ This document outlines the detailed, phased development plan for the "Veritas" v
 -   **[x] 5.4: Use singlegenerator for code generation**
     -   [x] 5.4.1: Refactor the code generation to use `singlegenerator`.
     -   [x] 5.4.2: Add tests for the new code generation implementation.
+
+## Phase 6: Additional Tasks
+
+- [x] Embed `rules.json` in `main.go`
+- [x] Update `run` function to use embedded data
+- [x] Format the code
+- [x] Run tests
+- [x] Update `TODO.md`

--- a/examples/http-server/main.go
+++ b/examples/http-server/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	_ "embed"
+
 	"context"
 	"encoding/json"
 	"errors"
@@ -10,6 +12,9 @@ import (
 
 	"github.com/podhmo/veritas"
 )
+
+//go:embed rules.json
+var rulesJSON []byte
 
 type User struct {
 	Name  string `json:"name"`
@@ -27,7 +32,8 @@ func main() {
 func run(ctx context.Context) error {
 	// setup validator
 	slog.InfoContext(ctx, "setup validator")
-	v, err := veritas.NewValidatorFromJSONFile("./rules.json", veritas.WithTypeAdapters(
+	provider := veritas.NewBytesRuleProvider(rulesJSON)
+	v, err := veritas.NewValidator(veritas.WithRuleProvider(provider), veritas.WithTypeAdapters(
 		map[string]veritas.TypeAdapter{
 			"http-server.User": func(ob any) (map[string]any, error) {
 				v, ok := ob.(User)

--- a/rules_bytes.go
+++ b/rules_bytes.go
@@ -1,0 +1,25 @@
+package veritas
+
+import (
+	"encoding/json"
+)
+
+// BytesRuleProvider loads validation rules from a byte slice.
+// It implements the RuleProvider interface.
+type BytesRuleProvider struct {
+	bytes []byte
+}
+
+// NewBytesRuleProvider creates a new provider that reads from the specified byte slice.
+func NewBytesRuleProvider(bytes []byte) *BytesRuleProvider {
+	return &BytesRuleProvider{bytes: bytes}
+}
+
+// GetRuleSets parses the byte slice into a map of validation rule sets.
+func (p *BytesRuleProvider) GetRuleSets() (map[string]ValidationRuleSet, error) {
+	var rules map[string]ValidationRuleSet
+	if err := json.Unmarshal(p.bytes, &rules); err != nil {
+		return nil, err
+	}
+	return rules, nil
+}


### PR DESCRIPTION
I've refactored the http-server example to use go:embed for loading validation rules.

This change introduces a `BytesRuleProvider` to load rules from a byte slice, allowing `rules.json` to be embedded directly into the Go binary. This simplifies deployment by removing the need for a separate rules file.

- I added `rules_bytes.go` with `BytesRuleProvider`.
- I modified `examples/http-server/main.go` to use `go:embed` and the new provider.
- I updated `TODO.md` to reflect the completed work.