### PR TITLE
Test simplify go module

### DIFF
--- a/cmd/veritas/gen/analyzer_test.go
+++ b/cmd/veritas/gen/analyzer_test.go
@@ -1,14 +1,21 @@
 package gen_test
 
 import (
+	"bytes"
 	"flag"
+	"fmt"
+	"go/types"
+	"io"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/gostaticanalysis/codegen/codegentest"
 	"github.com/podhmo/veritas/cmd/veritas/gen"
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/analysis/analysistest"
+	"golang.org/x/tools/go/analysis/checker"
+	"golang.org/x/tools/go/packages"
 )
 
 var flagUpdate bool
@@ -23,27 +30,97 @@ func TestGenerator(t *testing.T) {
 	dir := filepath.Join(codegentest.TestData(), "src")
 
 	// workaround for testdata/src/go.mod
+	// {
+	// 	cwd, err := os.Getwd()
+	// 	if err != nil {
+	// 		t.Fatalf("failed to get cwd: %v", err)
+	// 	}
+	// 	os.Chdir(dir)
+	// 	t.Cleanup(func() {
+	// 		os.Chdir(cwd)
+	// 	})
+	// }
+
+	os.Setenv("PWD", dir)
+
+	// rs := codegentest.Run(t, dir, gen.Generator, "testpkg/a")
+	// for _, r := range rs {
+	// 	r.Dir = strings.Replace(r.Dir, "src/src/testpkg", "src", 1) // workaround for codegentest
+
+	// 	if r.Err != nil {
+	// 		t.Errorf("failed to generate code: %v", r.Err)
+	// 	}
+	// 	if r.Output != nil {
+	// 		t.Log(r.Output.String())
+	// 	}
+	// }
+	// codegentest.Golden(t, rs, flagUpdate)
+
 	{
-		cwd, err := os.Getwd()
+		mode := packages.NeedName | packages.NeedFiles | packages.NeedCompiledGoFiles | packages.NeedImports |
+			packages.NeedTypes | packages.NeedTypesSizes | packages.NeedSyntax | packages.NeedTypesInfo |
+			packages.NeedDeps | packages.NeedModule
+		gowork := "off"
+		env := []string{"GO111MODULE=on", "GOPROXY=off", "GOWORK=" + gowork} // module mode
+		cfg := &packages.Config{
+			Mode:  mode,
+			Dir:   dir,
+			Tests: true,
+			Env:   append(os.Environ(), env...),
+		}
+		pkgs, err := packages.Load(cfg, "testpkg/a")
+
 		if err != nil {
-			t.Fatalf("failed to get cwd: %v", err)
+			t.Errorf("failed to load packages: %v", err)
 		}
-		os.Chdir(dir)
-		t.Cleanup(func() {
-			os.Chdir(cwd)
-		})
+
+		for _, pkg := range pkgs {
+			t.Logf("package: %s, files: %s", pkg.PkgPath, pkg.GoFiles)
+			t.Logf("error? %+v", pkg.Errors)
+		}
+		packages.PrintErrors(pkgs)
+
+		g, err := checker.Analyze([]*analysis.Analyzer{
+			gen.Generator.ToAnalyzer(),
+		}, pkgs, nil)
+
+		if err != nil {
+			t.Errorf("failed to create analyzer: %v", err)
+		}
+		if g == nil {
+			t.Fatal("analyzer is nil")
+		}
+
+		for act := range g.All() {
+			if err := act.Err; err != nil {
+				t.Errorf("failed to generate code: %v", err)
+			}
+		}
 	}
 
-	rs := codegentest.Run(t, dir, gen.Generator, "testpkg/a")
-	for _, r := range rs {
-		r.Dir = strings.Replace(r.Dir, "src/src/testpkg", "src", 1) // workaround for codegentest
+	fmt.Println("````````````````````````````````````````")
+	{
+		outputs := map[*types.Package]*bytes.Buffer{}
+		g := gen.Generator
 
-		if r.Err != nil {
-			t.Errorf("failed to generate code: %v", r.Err)
+		g.Output = func(pkg *types.Package) io.Writer {
+			t.Logf("loading package: %s", pkg.Path())
+			var buf bytes.Buffer
+			outputs[pkg] = &buf
+			return &buf
 		}
-		if r.Output != nil {
-			t.Log(r.Output.String())
+
+		rs := analysistest.Run(t, dir, gen.Generator.ToAnalyzer(), "testpkg/a")
+		for _, r := range rs {
+			if r.Err != nil {
+				t.Errorf("failed to generate code: %v", r.Err)
+			}
+
+			output := outputs[r.Pass.Pkg]
+			if output != nil {
+				t.Log(output.String())
+			}
 		}
 	}
-	codegentest.Golden(t, rs, flagUpdate)
+
 }

--- a/cmd/veritas/gen/analyzer_test.go
+++ b/cmd/veritas/gen/analyzer_test.go
@@ -1,21 +1,14 @@
 package gen_test
 
 import (
-	"bytes"
 	"flag"
-	"fmt"
-	"go/types"
-	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/gostaticanalysis/codegen/codegentest"
 	"github.com/podhmo/veritas/cmd/veritas/gen"
-	"golang.org/x/tools/go/analysis"
-	"golang.org/x/tools/go/analysis/analysistest"
-	"golang.org/x/tools/go/analysis/checker"
-	"golang.org/x/tools/go/packages"
 )
 
 var flagUpdate bool
@@ -28,99 +21,18 @@ func TestMain(m *testing.M) {
 
 func TestGenerator(t *testing.T) {
 	dir := filepath.Join(codegentest.TestData(), "src")
+	rs := codegentest.Run(t, dir, gen.Generator, "testpkg/a")
 
-	// workaround for testdata/src/go.mod
-	// {
-	// 	cwd, err := os.Getwd()
-	// 	if err != nil {
-	// 		t.Fatalf("failed to get cwd: %v", err)
-	// 	}
-	// 	os.Chdir(dir)
-	// 	t.Cleanup(func() {
-	// 		os.Chdir(cwd)
-	// 	})
-	// }
+	for _, r := range rs {
+		r.Dir = strings.Replace(r.Dir, "src/src/testpkg", "src", 1) // workaround for codegentest
 
-	os.Setenv("PWD", dir)
-
-	// rs := codegentest.Run(t, dir, gen.Generator, "testpkg/a")
-	// for _, r := range rs {
-	// 	r.Dir = strings.Replace(r.Dir, "src/src/testpkg", "src", 1) // workaround for codegentest
-
-	// 	if r.Err != nil {
-	// 		t.Errorf("failed to generate code: %v", r.Err)
-	// 	}
-	// 	if r.Output != nil {
-	// 		t.Log(r.Output.String())
-	// 	}
-	// }
-	// codegentest.Golden(t, rs, flagUpdate)
-
-	{
-		mode := packages.NeedName | packages.NeedFiles | packages.NeedCompiledGoFiles | packages.NeedImports |
-			packages.NeedTypes | packages.NeedTypesSizes | packages.NeedSyntax | packages.NeedTypesInfo |
-			packages.NeedDeps | packages.NeedModule
-		gowork := "off"
-		env := []string{"GO111MODULE=on", "GOPROXY=off", "GOWORK=" + gowork} // module mode
-		cfg := &packages.Config{
-			Mode:  mode,
-			Dir:   dir,
-			Tests: true,
-			Env:   append(os.Environ(), env...),
+		if r.Err != nil {
+			t.Errorf("failed to generate code: %v", r.Err)
 		}
-		pkgs, err := packages.Load(cfg, "testpkg/a")
-
-		if err != nil {
-			t.Errorf("failed to load packages: %v", err)
-		}
-
-		for _, pkg := range pkgs {
-			t.Logf("package: %s, files: %s", pkg.PkgPath, pkg.GoFiles)
-			t.Logf("error? %+v", pkg.Errors)
-		}
-		packages.PrintErrors(pkgs)
-
-		g, err := checker.Analyze([]*analysis.Analyzer{
-			gen.Generator.ToAnalyzer(),
-		}, pkgs, nil)
-
-		if err != nil {
-			t.Errorf("failed to create analyzer: %v", err)
-		}
-		if g == nil {
-			t.Fatal("analyzer is nil")
-		}
-
-		for act := range g.All() {
-			if err := act.Err; err != nil {
-				t.Errorf("failed to generate code: %v", err)
-			}
+		if r.Output != nil {
+			t.Log(r.Output.String())
 		}
 	}
 
-	fmt.Println("````````````````````````````````````````")
-	{
-		outputs := map[*types.Package]*bytes.Buffer{}
-		g := gen.Generator
-
-		g.Output = func(pkg *types.Package) io.Writer {
-			t.Logf("loading package: %s", pkg.Path())
-			var buf bytes.Buffer
-			outputs[pkg] = &buf
-			return &buf
-		}
-
-		rs := analysistest.Run(t, dir, gen.Generator.ToAnalyzer(), "testpkg/a")
-		for _, r := range rs {
-			if r.Err != nil {
-				t.Errorf("failed to generate code: %v", r.Err)
-			}
-
-			output := outputs[r.Pass.Pkg]
-			if output != nil {
-				t.Log(output.String())
-			}
-		}
-	}
-
+	codegentest.Golden(t, rs, flagUpdate)
 }

--- a/cmd/veritas/gen/testdata/src/a/gogen.golden
+++ b/cmd/veritas/gen/testdata/src/a/gogen.golden
@@ -5,7 +5,7 @@ import (
 )
 
 func init() {
-	veritas.Register("a.User", veritas.ValidationRuleSet{
+	veritas.Register("testpkg/a.User", veritas.ValidationRuleSet{
 		TypeRules: []string{
 			`self.Email != ""`,
 		},

--- a/cmd/veritas/gen/testdata/src/go.mod
+++ b/cmd/veritas/gen/testdata/src/go.mod
@@ -1,0 +1,3 @@
+module testpkg
+
+go 1.24.3


### PR DESCRIPTION
This pull request updates the test generator in the `cmd/veritas/gen` package to improve test organization and fix path-related issues. The most important changes include restructuring test data paths, addressing a known workaround for `codegentest`, and updating related test files accordingly.

### Test generator improvements:

* [`cmd/veritas/gen/analyzer_test.go`](diffhunk://#diff-f967ee6b247f541d6bf4fd9910ddca15a2f03a8221b3cc6d1e203ec0e9e05b86L5-R7): Updated the test data directory to include a "src" subdirectory, added a workaround for path inconsistencies in `codegentest`, and removed unused imports and environment variable configurations. [[1]](diffhunk://#diff-f967ee6b247f541d6bf4fd9910ddca15a2f03a8221b3cc6d1e203ec0e9e05b86L5-R7) [[2]](diffhunk://#diff-f967ee6b247f541d6bf4fd9910ddca15a2f03a8221b3cc6d1e203ec0e9e05b86L22-R36)

### Test data updates:

* [`cmd/veritas/gen/testdata/src/a/gogen.golden`](diffhunk://#diff-c8be265ae1b78c1e9ec218505e0a8bf382354fb38d25806805f582f162eaa8c2L8-R8): Modified the `veritas.Register` call to use the fully qualified type name (`testpkg/a.User`) for consistency with the new directory structure.
* [`cmd/veritas/gen/testdata/src/go.mod`](diffhunk://#diff-3e3a801b19877a831c68da816782f313b63ba6c6f0e211109bb667de8a13ae2fR1-R3): Added a `go.mod` file to define the module name (`testpkg`) and specify the Go version, aligning with the updated test data structure.