### PR TITLE
docs: update remove-adapter-plan.md and TODO.md

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -182,3 +182,11 @@ This document outlines the detailed, phased development plan for the "Veritas" v
     -   [ ] Update `README.md` to reflect the new, simpler API.
     -   [ ] Update the `examples/http-server/main.go` to remove the `TypeAdapter` and use the new `WithTypes` option.
     -   [ ] Update all other relevant documentation.
+
+- [ ] **ISSUE: `unsupported type` error when using `cel.Types()`**
+    - I attempted to remove the adapter pattern by using `cel.Types()` to register the Go structs with `cel-go`. However, this resulted in an `unsupported type` error at runtime.
+    - **What I tried:**
+        - Passing the types to `cel.NewEnv()` using the `cel.Types()` option.
+        - Extending the `cel.Env` with the types after it was created.
+        - Changing the "self" variable to `types.DynType`.
+    - **Conclusion:** None of these approaches worked. It seems that `cel-go`'s support for native Go structs is not as straightforward as I had hoped. I have reverted all changes related to this effort. The adapter pattern will remain in place for now.


### PR DESCRIPTION
This commit updates the `docs/remove-adapter-plan.md` and `TODO.md` files to document my failed attempt to remove the adapter pattern.

The `docs/remove-adapter-plan.md` file now includes details about the approaches that I tried, the results that were observed, and the specific error messages that were encountered.

The `TODO.md` file has been updated to reflect the issue and my conclusion that the adapter pattern will remain in place for now.

This information will be useful for future attempts to remove the adapter pattern.