### PR TITLE
feat(validator): Introduce WithTypes for native validation

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -155,11 +155,11 @@ This document outlines the detailed, phased development plan for the "Veritas" v
 
 **Goal**: Remove the `TypeAdapter` pattern to simplify the API and improve performance by using `cel-go`'s native struct support. This will be done incrementally to minimize risk. For more details, see [docs/remove-adapter-plan.md](docs/remove-adapter-plan.md).
 
--   [ ] **8.1: Introduce `WithTypes` Option**
-    -   [ ] Create a new `ValidatorOption` called `WithTypes(types ...any)`.
-    -   [ ] This option will take a variadic list of Go struct instances (e.g., `User{}`).
-    -   [ ] Inside `NewValidator`, if this option is present, use the types to create a `cel.Env` with `ext.NativeTypes()`.
-    -   [ ] The validation logic will be updated to use the native path if the new env is available, otherwise it will fall back to the existing adapter path.
+-   [x] **8.1: Introduce `WithTypes` Option**
+    -   [x] Create a new `ValidatorOption` called `WithTypes(types ...any)`.
+    -   [x] This option will take a variadic list of Go struct instances (e.g., `User{}`).
+    -   [x] Inside `NewValidator`, if this option is present, use the types to create a `cel.Env` with `ext.NativeTypes()`.
+    -   [x] The validation logic will be updated to use the native path if the new env is available, otherwise it will fall back to the existing adapter path.
 
 -   [ ] **8.2: Update `NewValidatorFromJSONFile`**
     -   [ ] Modify `NewValidatorFromJSONFile` to accept the new `WithTypes` option.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/podhmo/veritas
 
 go 1.24
+
 toolchain go1.24.3
 
 require (
@@ -18,6 +19,7 @@ require (
 	golang.org/x/exp v0.0.0-20250718183923-645b1fa84792 // indirect
 	golang.org/x/mod v0.26.0 // indirect
 	golang.org/x/sync v0.16.0 // indirect
+	golang.org/x/text v0.23.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20250715232539-7130f93afb79 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250715232539-7130f93afb79 // indirect
 	google.golang.org/protobuf v1.36.6 // indirect

--- a/testdata/rules/user.json
+++ b/testdata/rules/user.json
@@ -83,7 +83,7 @@
     ],
     "fieldRules": {
       "Email": [
-        "self != \"\" \u0026\u0026 self.matches('^[^\\\\s@]+@[^\\\\s@]+\\\\.[^\\\\s@]+$')"
+        "self != \"\" && self.matches('^[^\\\\s@]+@[^\\\\s@]+\\\\.[^\\\\s@]+$')"
       ],
       "ID": [
         "self != null"

--- a/testdata/rules/user_native.json
+++ b/testdata/rules/user_native.json
@@ -1,0 +1,18 @@
+{
+  "sources.MockUser": {
+    "typeRules": [
+      "self.Age >= 18"
+    ],
+    "fieldRules": {
+      "Email": [
+        "self.Email != \"\" && self.Email.matches('^[^\\\\s@]+@[^\\\\s@]+\\\\.[^\\\\s@]+$')"
+      ],
+      "ID": [
+        "has(self.ID)"
+      ],
+      "Name": [
+        "self.Name != \"\""
+      ]
+    }
+  }
+}


### PR DESCRIPTION
This commit introduces the `WithTypes` validator option, laying the groundwork for removing the TypeAdapter pattern.

`WithTypes` allows you to register your Go structs directly with the CEL environment using `ext.NativeTypes`. When this option is used, the validator will use a new "native" validation path that operates directly on the structs, bypassing the need for manual struct-to-map adapters.

- Added `WithTypes(...any) ValidatorOption`.
- Updated `NewValidator` to create a `nativeEnv` when `WithTypes` is used.
- Implemented a separate validation path (`validateNative`) for this new environment.
- Added `TestValidator_Validate_Native` to test the new functionality with a dedicated set of rules (`user_native.json`).
- The existing adapter-based path (`validateWithAdapter`) remains functional to ensure backward compatibility during the transition.