### PR TITLE
feat(gen): generate GetKnownTypes function

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -171,14 +171,14 @@ This document outlines the detailed, phased development plan for the "Veritas" v
     -   [x] Verified the example works as expected.
     -   **Note**: This required fixing `getTypeName` to use full package paths and ensuring the `fieldEnv` included the standard library.
 
--   [ ] **8.4: Enhance `veritas-gen` for Type Generation**
-    -   [ ] Modify the `veritas-gen` tool (`--format=go`) to generate a new function, e.g., `GetKnownTypes() []any`.
-    -   [ ] This function will return a slice of instances of all the types for which validation rules were generated (e.g., `[]any{User{}, Post{}}`).
-    -   **Status**: Postponed. The implementation is complex due to cross-package type references.
+-   [x] **8.4: Enhance `veritas-gen` for Type Generation**
+    -   [x] Modify the `veritas-gen` tool (`--format=go`) to generate a new function, e.g., `GetKnownTypes() []any`.
+    -   [x] This function will return a slice of instances of all the types for which validation rules were generated (e.g., `[]any{User{}, Post{}}`).
+    -   **Status**: Done.
 
--   [ ] **8.5: Update `gencode` Example**
-    -   [ ] Refactor `examples/gencode/main.go` to call the new `GetKnownTypes()` function from the generated code.
-    -   **Status**: Postponed.
+-   [x] **8.5: Update `gencode` Example**
+    -   [x] Refactor `examples/gencode/main.go` to call the new `GetKnownTypes()` function from the generated code.
+    -   **Status**: Done.
 
 -   [ ] **8.6: Deprecate and Remove `TypeAdapter` (Postponed)**
     -   **Note**: The full removal of the `TypeAdapter` is postponed due to complexities with `cel-go`'s native type support for generics and nil pointers. The `TypeAdapter` will remain as a fallback mechanism. The `WithTypes` option is now the recommended path for simple, non-generic structs. A more detailed plan for full removal is needed. See `docs/remove-adapter-plan.md` for a summary of the challenges.

--- a/cmd/veritas/gen/testdata/src/a/gogen.golden
+++ b/cmd/veritas/gen/testdata/src/a/gogen.golden
@@ -1,7 +1,8 @@
-package a
+package validation
 
 import (
-	"github.com/podhmo/veritas"
+	veritas "github.com/podhmo/veritas"
+	a "testpkg/a"
 )
 
 func init() {
@@ -18,4 +19,11 @@ func init() {
 			},
 		},
 	})
+}
+
+// GetKnownTypes returns a list of all types that have validation rules.
+func GetKnownTypes() []any {
+	return []any{
+		a.User{},
+	}
 }

--- a/cmd/veritas/parser/parser_test.go
+++ b/cmd/veritas/parser/parser_test.go
@@ -97,7 +97,7 @@ func TestParser(t *testing.T) {
 		}
 
 		// Parse the directory containing the test file.
-		got, err := p.Parse("github.com/podhmo/veritas/testdata/sources")
+		got, _, err := p.Parse("github.com/podhmo/veritas/testdata/sources")
 		if err != nil {
 			t.Fatalf("Parse() error = %v, want nil", err)
 		}

--- a/examples/gencode/def/user.go
+++ b/examples/gencode/def/user.go
@@ -1,5 +1,7 @@
 package def
 
+//go:generate go run ../../../cmd/veritas -o ../validation/validator.go .
+
 // veritas:
 type User struct {
 	Name  string `json:"name" validate:"cel:self.size() > 0"`

--- a/examples/gencode/main.go
+++ b/examples/gencode/main.go
@@ -6,16 +6,10 @@ import (
 	"log/slog"
 	"os"
 
-	"reflect"
-
 	"github.com/podhmo/veritas"
-	_ "github.com/podhmo/veritas/examples/gencode/validation"
+	"github.com/podhmo/veritas/examples/gencode/def"
+	"github.com/podhmo/veritas/examples/gencode/validation"
 )
-
-type User struct {
-	Name  string
-	Email string
-}
 
 func main() {
 	if err := run(); err != nil {
@@ -27,23 +21,7 @@ func main() {
 func run() error {
 	ctx := context.Background()
 	v, err := veritas.NewValidator(
-		veritas.WithTypeAdapters(
-			map[reflect.Type]veritas.TypeAdapterTarget{
-				reflect.TypeOf(User{}): { // KEY is reflect.Type
-					TargetName: "github.com/podhmo/veritas/examples/gencode/def.User", // TARGET rule set
-					Adapter: func(ob any) (map[string]any, error) {
-						v, ok := ob.(User)
-						if !ok {
-							return nil, fmt.Errorf("unexpected type %T", ob)
-						}
-						return map[string]any{
-							"Name":  v.Name,
-							"Email": v.Email,
-						}, nil
-					},
-				},
-			},
-		),
+		veritas.WithTypes(validation.GetKnownTypes()...),
 	)
 	if err != nil {
 		return fmt.Errorf("failed to create validator: %w", err)
@@ -51,7 +29,7 @@ func run() error {
 
 	// valid
 	{
-		user := User{Name: "foo", Email: "foo@example.com"}
+		user := def.User{Name: "foo", Email: "foo@example.com"}
 		if err := v.Validate(ctx, user); err != nil {
 			return fmt.Errorf("validation failed, unexpectedly: %+v", err)
 		}
@@ -60,7 +38,7 @@ func run() error {
 
 	// invalid
 	{
-		user := User{Name: "foo", Email: "foo"}
+		user := def.User{Name: "foo", Email: "foo"}
 		if err := v.Validate(ctx, user); err != nil {
 			slog.Info("validation failed, as expected", "user", user, "err", err)
 		} else {

--- a/examples/gencode/validation/validator.go
+++ b/examples/gencode/validation/validator.go
@@ -1,7 +1,8 @@
-package def
+package validation
 
 import (
-	"github.com/podhmo/veritas"
+	veritas "github.com/podhmo/veritas"
+	def "github.com/podhmo/veritas/examples/gencode/def"
 )
 
 func init() {
@@ -15,4 +16,11 @@ func init() {
 			},
 		},
 	})
+}
+
+// GetKnownTypes returns a list of all types that have validation rules.
+func GetKnownTypes() []any {
+	return []any{
+		def.User{},
+	}
 }

--- a/testdata/rules/user_and_profile.json
+++ b/testdata/rules/user_and_profile.json
@@ -1,17 +1,17 @@
 {
-    "sources.MockUser": {
+    "github.com/podhmo/veritas/testdata/sources.MockUser": {
         "typeRules": [
             "self.Age >= 18"
         ],
         "fieldRules": {
             "Name": [
-                "self.Name != \"\""
+                "self != \"\""
             ],
             "Email": [
-                "self.Email != \"\" && self.Email.matches('^[^\\\\s@]+@[^\\\\s@]+\\\\.[^\\\\s@]+$')"
+                "self != \"\" && self.matches('^[^\\\\s@]+@[^\\\\s@]+\\\\.[^\\\\s@]+$')"
             ],
             "ID": [
-                "has(self.ID)"
+                "self != null"
             ]
         }
     },

--- a/testdata/rules/user_native.json
+++ b/testdata/rules/user_native.json
@@ -1,5 +1,5 @@
 {
-  "sources.MockUser": {
+  "github.com/podhmo/veritas/testdata/sources.MockUser": {
     "typeRules": [
       "self.Age >= 18"
     ],

--- a/validator.go
+++ b/validator.go
@@ -206,7 +206,6 @@ func (v *Validator) Validate(ctx context.Context, obj any) error {
 	if val.Kind() != reflect.Struct {
 		return nil // Or perhaps an error? For now, we only validate structs.
 	}
-	typ := val.Type()
 
 	// Use a helper function to perform the validation recursively.
 	v.validateRecursive(ctx, obj, &allErrors)

--- a/validator_test.go
+++ b/validator_test.go
@@ -900,7 +900,7 @@ func TestValidator_NewValidatorFromJSONFile_WithTypesAndAdapters(t *testing.T) {
 					Handle:   "gopher",
 				},
 			},
-			wantErr: NewValidationError("sources.MockUser", "Email", `self.Email != "" && self.Email.matches('^[^\\s@]+@[^\\s@]+\\.[^\\s@]+$')`),
+			wantErr: NewValidationError("github.com/podhmo/veritas/testdata/sources.MockUser", "Email", `self != "" && self.matches('^[^\\s@]+@[^\\s@]+\\.[^\\s@]+$')`),
 		},
 		{
 			name: "native valid, adapter invalid",
@@ -933,7 +933,7 @@ func TestValidator_NewValidatorFromJSONFile_WithTypesAndAdapters(t *testing.T) {
 				},
 			},
 			errMsgs: []string{
-				NewValidationError("sources.MockUser", "Name", `self.Name != ""`).Error(),
+				NewValidationError("github.com/podhmo/veritas/testdata/sources.MockUser", "Name", `self != ""`).Error(),
 				NewValidationError("sources.Profile", "Platform", `self != ""`).Error(),
 			},
 		},


### PR DESCRIPTION
The veritas-gen tool now generates a `GetKnownTypes()` function in the output file. This function returns a slice of instances of all types for which validation rules were generated.

This simplifies the validator setup, as you can now pass `validation.GetKnownTypes()` to `veritas.WithTypes()` instead of manually listing all the types.

- Enhance `veritas-gen` to produce the `GetKnownTypes` function.
- Update the `gencode` example to use this new function, removing the need for the manual TypeAdapter pattern.
- Fix initial test failures related to native validation rule key resolution.
- Update tests for `parser` and `gen` to reflect the changes.