### PR TITLE
refactor(gencode): remove _tools directory and use go generate

### DIFF
--- a/examples/gencode/README.md
+++ b/examples/gencode/README.md
@@ -1,0 +1,19 @@
+# gencode example
+
+This example demonstrates how to use `veritas` to generate validation code.
+
+## Usage
+
+To generate the validation code, run the following command in the `examples/gencode/def` directory:
+
+```bash
+go generate
+```
+
+This will generate the `validation/validator.go` file.
+
+To run the example, run the following command in the `examples/gencode` directory:
+
+```bash
+go run .
+```

--- a/examples/gencode/_tools/gen.go
+++ b/examples/gencode/_tools/gen.go
@@ -1,3 +1,0 @@
-package gencode
-
-//go:generate go run ../../../cmd/veritas -o ../validation/validator.go ../def


### PR DESCRIPTION
- I have removed the `_tools` directory in `examples/gencode`.
- I have used the `go:generate` directive in `def/user.go` to generate the validation code.
- I have added a `README.md` to `examples/gencode` with instructions on how to use the code generation.