### PR TITLE
feat: add -pkg option to specify package name

### DIFF
--- a/cmd/veritas/gen/analyzer.go
+++ b/cmd/veritas/gen/analyzer.go
@@ -17,7 +17,8 @@ import (
 const doc = "gogen is a tool to generate validation code from Go source code."
 
 var (
-	flagOutput string
+	flagOutput  string
+	flagPackage string
 )
 
 var Generator = &codegen.Generator{
@@ -28,6 +29,7 @@ var Generator = &codegen.Generator{
 
 func init() {
 	Generator.Flags.StringVar(&flagOutput, "o", "", "output file name")
+	Generator.Flags.StringVar(&flagPackage, "pkg", "validation", "package name")
 }
 
 func run(pass *codegen.Pass) error {
@@ -88,8 +90,7 @@ func (g *GoCodeGenerator) Generate(pkgName string, ruleSets map[string]veritas.V
 	}
 
 	// 2. Print package and imports
-	// TODO: make package name configurable
-	fmt.Fprintf(&buf, "package validation\n\n")
+	fmt.Fprintf(&buf, "package %s\n\n", flagPackage)
 	fmt.Fprintf(&buf, "import (\n")
 	// Sort imports for deterministic output
 	importAliases := make([]string, 0, len(imports))

--- a/cmd/veritas/gen/analyzer_test.go
+++ b/cmd/veritas/gen/analyzer_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/gostaticanalysis/codegen/codegentest"
 	"github.com/podhmo/veritas/cmd/veritas/gen"
 )
@@ -20,19 +21,57 @@ func TestMain(m *testing.M) {
 }
 
 func TestGenerator(t *testing.T) {
-	dir := filepath.Join(codegentest.TestData(), "src")
-	rs := codegentest.Run(t, dir, gen.Generator, "testpkg/a")
-
-	for _, r := range rs {
-		r.Dir = strings.Replace(r.Dir, "src/src/testpkg", "src", 1) // workaround for codegentest
-
-		if r.Err != nil {
-			t.Errorf("failed to generate code: %v", r.Err)
-		}
-		if r.Output != nil {
-			t.Log(r.Output.String())
-		}
+	cases := []struct {
+		Name    string
+		Args    []string
+		PkgPath string
+		Golden  string
+	}{
+		{
+			Name:    "default",
+			PkgPath: "testpkg/a",
+			Golden:  "testdata/src/a/gogen.golden",
+		},
+		{
+			Name:    "with-pkg-flag",
+			Args:    []string{"-pkg=myvalidation"},
+			PkgPath: "testpkg/a",
+			Golden:  "testdata/src/a/gogen.golden.pkg",
+		},
 	}
 
-	codegentest.Golden(t, rs, flagUpdate)
+	for _, c := range cases {
+		c := c
+		t.Run(c.Name, func(t *testing.T) {
+			gen.Generator.Flags.Parse(c.Args)
+
+			dir := filepath.Join(codegentest.TestData(), "src")
+			rs := codegentest.Run(t, dir, gen.Generator, c.PkgPath)
+
+			if len(rs) != 1 {
+				t.Fatalf("unexpected number of results: %d", len(rs))
+			}
+			r := rs[0]
+			r.Dir = strings.Replace(r.Dir, "src/src/testpkg", "src", 1) // workaround for codegentest
+
+			if r.Err != nil {
+				t.Errorf("failed to generate code: %v", r.Err)
+			}
+
+			if flagUpdate {
+				if err := os.WriteFile(c.Golden, r.Output.Bytes(), 0644); err != nil {
+					t.Fatalf("failed to update golden file: %v", err)
+				}
+				return
+			}
+
+			golden, err := os.ReadFile(c.Golden)
+			if err != nil {
+				t.Fatalf("failed to read golden file: %v", err)
+			}
+			if diff := cmp.Diff(string(golden), r.Output.String()); diff != "" {
+				t.Errorf("output differs from golden file:\n%s", diff)
+			}
+		})
+	}
 }

--- a/cmd/veritas/gen/testdata/src/a/gogen.golden.pkg
+++ b/cmd/veritas/gen/testdata/src/a/gogen.golden.pkg
@@ -1,0 +1,29 @@
+package myvalidation
+
+import (
+	veritas "github.com/podhmo/veritas"
+	a "testpkg/a"
+)
+
+func init() {
+	veritas.Register("testpkg/a.User", veritas.ValidationRuleSet{
+		TypeRules: []string{
+			`self.Email != ""`,
+		},
+		FieldRules: map[string][]string{
+			"Email": {
+				`self != "" && self.matches('^[^\\s@]+@[^\\s@]+\\.[^\\s@]+$')`,
+			},
+			"Name": {
+				`self != ""`,
+			},
+		},
+	})
+}
+
+// GetKnownTypes returns a list of all types that have validation rules.
+func GetKnownTypes() []any {
+	return []any{
+		a.User{},
+	}
+}


### PR DESCRIPTION
This commit adds a new option `-pkg` to the `veritas` command to allow specifying the package name for the generated code. The default value is `validation`.